### PR TITLE
可視化にデータを繋ぎこむ処理を実装

### DIFF
--- a/data/converter.ts
+++ b/data/converter.ts
@@ -1,0 +1,323 @@
+import * as fs from "fs";
+import * as path from "path";
+
+// import { Summary, Flow, Transaction } from '../type';
+type Summary = {
+	income: number;
+	expense: number;
+	balance: number;
+	year: number;
+};
+type Flow = {
+	id: string;
+	name: string;
+	direction: "income" | "expense";
+	value: number;
+	parent: string | null;
+};
+type Transaction = {
+	id: string;
+	name: string;
+	date: string;
+	value: number;
+	category: string;
+	percentage: number;
+};
+
+type InputCategory = {
+	id: string;
+	name: string;
+	parent: string | null;
+	direction: "income" | "expense";
+};
+type InputTransaction = {
+	id: string;
+	category_id: string;
+	name: string;
+	date: string;
+	value: number;
+};
+type InputData = {
+	year: number;
+	categories: InputCategory[];
+	transactions: InputTransaction[];
+};
+
+type OutputData = {
+	summary: Summary;
+	flows: Flow[];
+	incomeTransactions: Transaction[];
+	expenseTransactions: Transaction[];
+};
+
+function convert(data: InputData): OutputData {
+	const incomeCategoryIds = data.categories
+		.filter((c: InputCategory) => c.direction === "income")
+		.map((c: InputCategory) => c.id);
+	const expenseCategoryIds = data.categories
+		.filter((c: InputCategory) => c.direction === "expense")
+		.map((c: InputCategory) => c.id);
+
+	const incomeInputTransactions = data.transactions.filter(
+		(t: InputTransaction) => incomeCategoryIds.includes(t.category_id),
+	);
+	const expenseInputTransactions = data.transactions.filter(
+		(t: InputTransaction) => expenseCategoryIds.includes(t.category_id),
+	);
+
+	const totalIncome = incomeInputTransactions.reduce(
+		(sum: number, t: InputTransaction) => sum + t.value,
+		0,
+	);
+	const totalExpense = expenseInputTransactions.reduce(
+		(sum: number, t: InputTransaction) => sum + t.value,
+		0,
+	);
+	const nextYearCategory = data.categories.find(
+		(c: InputCategory) => c.name === "翌年度への繰越",
+	);
+	const balanceTransaction = data.transactions.find(
+		(t: InputTransaction) => t.category_id === nextYearCategory?.id,
+	);
+	const summary = {
+		income: totalIncome,
+		expense: totalExpense - (balanceTransaction ? balanceTransaction.value : 0),
+		balance: balanceTransaction ? balanceTransaction.value : 0,
+		year: data.year,
+	};
+
+	const categoryIdToName = data.categories.reduce(
+		(acc: Record<string, string>, c: InputCategory) => {
+			acc[c.id] = c.name;
+			return acc;
+		},
+		{},
+	);
+
+	const incomeTransactions = incomeInputTransactions.map(
+		(t: InputTransaction) => ({
+			id: t.id,
+			name: t.name,
+			date: t.date,
+			value: t.value,
+			category: categoryIdToName[t.category_id],
+			percentage: (t.value * 100.0) / totalIncome,
+		}),
+	);
+
+	const expenseTransactions = expenseInputTransactions.map(
+		(t: InputTransaction) => ({
+			id: t.id,
+			name: t.name,
+			date: t.date,
+			value: t.value,
+			category: categoryIdToName[t.category_id],
+			percentage: (t.value * 100.0) / totalExpense,
+		}),
+	);
+
+	const flows = data.categories.map((c: InputCategory) => ({
+		id: c.id,
+		name: c.name,
+		direction: c.direction,
+		value: 0,
+		parent: c.parent,
+	}));
+	const flowsByCategoryIdMap = flows.reduce(
+		(acc: Record<string, Flow>, f: Flow) => {
+			acc[f.id] = f;
+			return acc;
+		},
+		{},
+	);
+	for (const t of [...incomeInputTransactions, ...expenseInputTransactions]) {
+		let flow = flowsByCategoryIdMap[t.category_id];
+		flow.value += t.value;
+		// 親カテゴリの value は子カテゴリの value の合計なので、子カテゴリの value を親カテゴリに加算していく
+		while (flow.parent) {
+			flow = flowsByCategoryIdMap[flow.parent];
+			flow.value += t.value;
+		}
+	}
+	// root category は income と expense 両方の合計になるので、半分にする
+	const rootFlow = flows.find((f: Flow) => !f.parent);
+	if (rootFlow) {
+		rootFlow.value /= 2;
+	}
+
+	return {
+		summary,
+		flows,
+		incomeTransactions,
+		expenseTransactions,
+	};
+}
+
+function validateInput(data: any): void {
+	if (typeof data.year !== "number") {
+		throw new Error("year は数値である必要があります");
+	}
+	if (!data.categories || !data.transactions) {
+		throw new Error("categories と transactions が必要です");
+	}
+	if (!Array.isArray(data.categories)) {
+		throw new Error("categories は配列である必要があります");
+	}
+	if (!Array.isArray(data.transactions)) {
+		throw new Error("transactions は配列である必要があります");
+	}
+
+	for (const category of data.categories) {
+		if (!category.name || !category.direction) {
+			throw new Error(
+				`category は name, direction を持つ必要があります: ${JSON.stringify(category)}`,
+			);
+		}
+		if (category.direction !== "income" && category.direction !== "expense") {
+			throw new Error(
+				"category の direction は income か expense である必要があります",
+			);
+		}
+	}
+
+	if (!data.categories.find((c: any) => c.name === "前年度からの繰越")) {
+		throw new Error("カテゴリ「前年度からの繰越」が存在する必要があります");
+	}
+	if (!data.categories.find((c: any) => c.name === "翌年度への繰越")) {
+		throw new Error("カテゴリ「翌年度への繰越」が存在する必要があります");
+	}
+
+	const previousYearCategory = data.categories.find(
+		(c: any) => c.name === "前年度からの繰越",
+	);
+	const nextYearCategory = data.categories.find(
+		(c: any) => c.name === "翌年度への繰越",
+	);
+	const previousYearTransactions = data.transactions.filter(
+		(t: any) => t.category_id === previousYearCategory.id,
+	);
+	if (previousYearTransactions.length !== 1) {
+		throw new Error(
+			"前年度からの繰越の transaction はちょうど1つである必要があります",
+		);
+	}
+	const nextYearTransactions = data.transactions.filter(
+		(t: any) => t.category_id === nextYearCategory.id,
+	);
+	if (nextYearTransactions.length !== 1) {
+		throw new Error(
+			"翌年度への繰越の transaction はちょうど1つである必要があります",
+		);
+	}
+
+	const incomeCategoryIds = data.categories
+		.filter((c: any) => c.direction === "income")
+		.map((c: any) => c.id);
+	const expenseCategoryIds = data.categories
+		.filter((c: any) => c.direction === "expense")
+		.map((c: any) => c.id);
+	const totalIncome = data.transactions
+		.filter((t: any) => incomeCategoryIds.includes(t.category_id))
+		.reduce((sum: number, t: any) => sum + t.value, 0);
+	const totalExpense = data.transactions
+		.filter((t: any) => expenseCategoryIds.includes(t.category_id))
+		.reduce((sum: number, t: any) => sum + t.value, 0);
+	if (totalIncome !== totalExpense) {
+		throw new Error(
+			`income と expense の合計が一致しません: ${totalIncome} !== ${totalExpense}`,
+		);
+	}
+
+	const rootCategoryCount = data.categories.filter(
+		(c: any) => !c.parent,
+	).length;
+	if (rootCategoryCount !== 1) {
+		throw new Error("root category はちょうど1つである必要があります");
+	}
+
+	const categoryIds = data.categories.map((c: any) => c.id);
+	const parentCategoryIds = data.categories
+		.map((c: any) => c.parent)
+		.filter((p: any) => p !== null);
+	const leafCategoryIds = data.categories
+		.filter((c: any) => !parentCategoryIds.includes(c.id))
+		.map((c: any) => c.id);
+	for (const transaction of data.transactions) {
+		if (
+			!transaction.id ||
+			!transaction.category_id ||
+			!transaction.name ||
+			!transaction.date ||
+			!transaction.value
+		) {
+			throw new Error(
+				"transaction は id, category_id, name, date, value を持つ必要があります",
+			);
+		}
+		if (!categoryIds.includes(transaction.category_id)) {
+			throw new Error(
+				"transaction の category_id は categories に存在する必要があります",
+			);
+		}
+		if (!leafCategoryIds.includes(transaction.category_id)) {
+			throw new Error(
+				`transaction の category_id は葉カテゴリである必要があります: ${transaction.category_id}`,
+			);
+		}
+		if (typeof transaction.date !== "string") {
+			throw new Error("transaction の date は文字列である必要があります");
+		}
+		if (typeof transaction.value !== "number" || transaction.value <= 0) {
+			throw new Error("transaction の value は正数である必要があります");
+		}
+	}
+}
+
+function parseArguments(): { inputFile: string; outputFile: string } {
+	const args = process.argv.slice(2);
+	let inputFile = "";
+	let outputFile = "";
+
+	for (let i = 0; i < args.length; i++) {
+		if (args[i] === "-i" && i + 1 < args.length) {
+			inputFile = args[i + 1];
+			i++;
+		} else if (args[i] === "-o" && i + 1 < args.length) {
+			outputFile = args[i + 1];
+			i++;
+		}
+	}
+
+	if (!inputFile || !outputFile) {
+		console.error(
+			"使用方法: node generator.js -i <入力JSONファイル> -o <出力JSONファイル>",
+		);
+		process.exit(1);
+	}
+
+	return { inputFile, outputFile };
+}
+
+function main(): void {
+	try {
+		const { inputFile, outputFile } = parseArguments();
+
+		const inputPath = path.resolve(inputFile);
+		const rawData = fs.readFileSync(inputPath, "utf8");
+		const data = JSON.parse(rawData);
+
+		validateInput(data);
+
+		const convertedData = convert(data);
+
+		const outputPath = path.resolve(outputFile);
+		fs.writeFileSync(outputPath, JSON.stringify(convertedData, null, 2));
+
+		console.log(`処理が完了しました。出力ファイル: ${outputPath}`);
+	} catch (error) {
+		console.error("エラーが発生しました:", error);
+		process.exit(1);
+	}
+}
+
+main();

--- a/data/sample_input.json
+++ b/data/sample_input.json
@@ -1,0 +1,248 @@
+{
+  "year": 2025,
+  "categories": [
+    {
+      "id": "xxx1",
+      "name": "個人からの寄付",
+      "parent": "xxx66",
+      "direction": "income"
+    },
+    {
+      "id": "xxx2",
+      "name": "政治団体からの寄付",
+      "parent": "xxx66",
+      "direction": "income"
+    },
+    {
+      "id": "xxx3",
+      "name": "寄付",
+      "parent": "xxx66",
+      "direction": "income"
+    },
+    {
+      "id": "xxx4",
+      "name": "機関紙誌の発行その他の事業による収入",
+      "parent": "xxx66",
+      "direction": "income"
+    },
+    {
+      "id": "xxx5",
+      "name": "前年度からの繰越",
+      "parent": "xxx66",
+      "direction": "income"
+    },
+    {
+      "id": "xxx66",
+      "name": "総収入",
+      "parent": null,
+      "direction": "income"
+    },
+    {
+      "id": "xxx7",
+      "name": "経常経費",
+      "parent": "xxx66",
+      "direction": "expense"
+    },
+    {
+      "id": "xxx8",
+      "name": "人件費",
+      "parent": "xxx7",
+      "direction": "expense"
+    },
+    {
+      "id": "xxx9",
+      "name": "備品・消耗品費",
+      "parent": "xxx7",
+      "direction": "expense"
+    },
+    {
+      "id": "xxxa",
+      "name": "事務所費",
+      "parent": "xxx7",
+      "direction": "expense"
+    },
+    {
+      "id": "xxxb",
+      "name": "政治活動費",
+      "parent": "xxx66",
+      "direction": "expense"
+    },
+    {
+      "id": "xxxc",
+      "name": "組織活動費",
+      "parent": "xxxb",
+      "direction": "expense"
+    },
+    {
+      "id": "xxxcc",
+      "name": "組織活動費その他",
+      "parent": "xxxc",
+      "direction": "expense"
+    },
+    {
+      "id": "xxxd",
+      "name": "機関紙の発行その他の事業費",
+      "parent": "xxxc",
+      "direction": "expense"
+    },
+    {
+      "id": "xxxe",
+      "name": "政治資金パーティー開催事業費",
+      "parent": "xxxd",
+      "direction": "expense"
+    },
+    {
+      "id": "xxxf",
+      "name": "調査研究費",
+      "parent": "xxxb",
+      "direction": "expense"
+    },
+    {
+      "id": "xxxg",
+      "name": "寄付・交付金",
+      "parent": "xxxb",
+      "direction": "expense"
+    },
+    {
+      "id": "xxxh",
+      "name": "翌年度への繰越",
+      "parent": "xxx66",
+      "direction": "expense"
+    }
+  ],
+  "transactions": [
+    {
+      "id": "xxx1",
+      "category_id": "xxxcc",
+      "name": "飲食代",
+      "date": "R5/6/28",
+      "value": 10200
+    },
+    {
+      "id": "xxx2",
+      "category_id": "xxxcc",
+      "name": "意見交換会会費",
+      "date": "R5/7/20",
+      "value": 12000
+    },
+    {
+      "id": "xxx3",
+      "category_id": "xxxcc",
+      "name": "飲食料",
+      "date": "R5/7/25",
+      "value": 152650
+    },
+    {
+      "id": "xxx4",
+      "category_id": "xxxcc",
+      "name": "飲食料",
+      "date": "R5/7/25",
+      "value": 152650
+    },
+    {
+      "id": "xxx5",
+      "category_id": "xxxcc",
+      "name": "飲食料",
+      "date": "R5/7/25",
+      "value": 152650
+    },
+    {
+      "id": "xxx6",
+      "category_id": "xxxcc",
+      "name": "飲食代",
+      "date": "R5/7/27",
+      "value": 17770
+    },
+    {
+      "id": "xxx7",
+      "category_id": "xxxcc",
+      "name": "飲食代",
+      "date": "R5/8/8",
+      "value": 67200
+    },
+    {
+      "id": "xxx8",
+      "category_id": "xxxcc",
+      "name": "食事代",
+      "date": "R5/8/9",
+      "value": 53179
+    },
+    {
+      "id": "xxx9",
+      "category_id": "xxxcc",
+      "name": "飲食代",
+      "date": "R5/8/30",
+      "value": 10640
+    },
+    {
+      "id": "xxx10",
+      "category_id": "xxxcc",
+      "name": "食事代",
+      "date": "R5/10/25",
+      "value": 14490
+    },
+    {
+      "id": "xxx11",
+      "category_id": "xxxcc",
+      "name": "飲食料他",
+      "date": "R5/10/30",
+      "value": 45000
+    },
+    {
+      "id": "xxx12",
+      "category_id": "xxxcc",
+      "name": "飲食代＋お土産代",
+      "date": "R5/11/27",
+      "value": 121528
+    },
+    {
+      "id": "xxx13",
+      "category_id": "xxxcc",
+      "name": "飲食代",
+      "date": "R5/11/28",
+      "value": 20320
+    },
+    {
+      "id": "xxx14",
+      "category_id": "xxxcc",
+      "name": "飲食代",
+      "date": "R5/12/25",
+      "value": 10920
+    },
+    {
+      "id": "xxx15",
+      "category_id": "xxx5",
+      "name": "前年度からの繰越",
+      "date": "R5/01/01",
+      "value": 1000000
+    },
+    {
+      "id": "xxx16",
+      "category_id": "xxxh",
+      "name": "翌年度への繰越",
+      "date": "R5/12/31",
+      "value": 458803
+    },
+    {
+      "id": "xxx17",
+      "category_id": "xxx1",
+      "name": "個人からの寄付",
+      "date": "R5/12/31",
+      "value": 100000
+    },
+    {
+      "id": "xxx18",
+      "category_id": "xxx1",
+      "name": "個人からの寄付",
+      "date": "R5/12/31",
+      "value": 100000
+    },
+    {
+      "id": "xxx19",
+      "category_id": "xxx1",
+      "name": "政治団体からの寄付",
+      "date": "R5/12/31",
+      "value": 100000
+    }
+  ]
+}

--- a/data/sample_output.json
+++ b/data/sample_output.json
@@ -1,0 +1,292 @@
+{
+  "summary": {
+    "income": 1300000,
+    "expense": 841197,
+    "balance": 458803,
+    "year": 2025
+  },
+  "flows": [
+    {
+      "id": "xxx1",
+      "name": "個人からの寄付",
+      "direction": "income",
+      "value": 300000,
+      "parent": "xxx66"
+    },
+    {
+      "id": "xxx2",
+      "name": "政治団体からの寄付",
+      "direction": "income",
+      "value": 0,
+      "parent": "xxx66"
+    },
+    {
+      "id": "xxx3",
+      "name": "寄付",
+      "direction": "income",
+      "value": 0,
+      "parent": "xxx66"
+    },
+    {
+      "id": "xxx4",
+      "name": "機関紙誌の発行その他の事業による収入",
+      "direction": "income",
+      "value": 0,
+      "parent": "xxx66"
+    },
+    {
+      "id": "xxx5",
+      "name": "前年度からの繰越",
+      "direction": "income",
+      "value": 1000000,
+      "parent": "xxx66"
+    },
+    {
+      "id": "xxx66",
+      "name": "総収入",
+      "direction": "income",
+      "value": 1300000,
+      "parent": null
+    },
+    {
+      "id": "xxx7",
+      "name": "経常経費",
+      "direction": "expense",
+      "value": 0,
+      "parent": "xxx66"
+    },
+    {
+      "id": "xxx8",
+      "name": "人件費",
+      "direction": "expense",
+      "value": 0,
+      "parent": "xxx7"
+    },
+    {
+      "id": "xxx9",
+      "name": "備品・消耗品費",
+      "direction": "expense",
+      "value": 0,
+      "parent": "xxx7"
+    },
+    {
+      "id": "xxxa",
+      "name": "事務所費",
+      "direction": "expense",
+      "value": 0,
+      "parent": "xxx7"
+    },
+    {
+      "id": "xxxb",
+      "name": "政治活動費",
+      "direction": "expense",
+      "value": 841197,
+      "parent": "xxx66"
+    },
+    {
+      "id": "xxxc",
+      "name": "組織活動費",
+      "direction": "expense",
+      "value": 841197,
+      "parent": "xxxb"
+    },
+    {
+      "id": "xxxcc",
+      "name": "組織活動費その他",
+      "direction": "expense",
+      "value": 841197,
+      "parent": "xxxc"
+    },
+    {
+      "id": "xxxd",
+      "name": "機関紙の発行その他の事業費",
+      "direction": "expense",
+      "value": 0,
+      "parent": "xxxc"
+    },
+    {
+      "id": "xxxe",
+      "name": "政治資金パーティー開催事業費",
+      "direction": "expense",
+      "value": 0,
+      "parent": "xxxd"
+    },
+    {
+      "id": "xxxf",
+      "name": "調査研究費",
+      "direction": "expense",
+      "value": 0,
+      "parent": "xxxb"
+    },
+    {
+      "id": "xxxg",
+      "name": "寄付・交付金",
+      "direction": "expense",
+      "value": 0,
+      "parent": "xxxb"
+    },
+    {
+      "id": "xxxh",
+      "name": "翌年度への繰越",
+      "direction": "expense",
+      "value": 458803,
+      "parent": "xxx66"
+    }
+  ],
+  "incomeTransactions": [
+    {
+      "id": "xxx15",
+      "name": "前年度からの繰越",
+      "date": "R5/01/01",
+      "value": 1000000,
+      "category": "前年度からの繰越",
+      "percentage": 76.92307692307692
+    },
+    {
+      "id": "xxx17",
+      "name": "個人からの寄付",
+      "date": "R5/12/31",
+      "value": 100000,
+      "category": "個人からの寄付",
+      "percentage": 7.6923076923076925
+    },
+    {
+      "id": "xxx18",
+      "name": "個人からの寄付",
+      "date": "R5/12/31",
+      "value": 100000,
+      "category": "個人からの寄付",
+      "percentage": 7.6923076923076925
+    },
+    {
+      "id": "xxx19",
+      "name": "政治団体からの寄付",
+      "date": "R5/12/31",
+      "value": 100000,
+      "category": "個人からの寄付",
+      "percentage": 7.6923076923076925
+    }
+  ],
+  "expenseTransactions": [
+    {
+      "id": "xxx1",
+      "name": "飲食代",
+      "date": "R5/6/28",
+      "value": 10200,
+      "category": "組織活動費その他",
+      "percentage": 0.7846153846153846
+    },
+    {
+      "id": "xxx2",
+      "name": "意見交換会会費",
+      "date": "R5/7/20",
+      "value": 12000,
+      "category": "組織活動費その他",
+      "percentage": 0.9230769230769231
+    },
+    {
+      "id": "xxx3",
+      "name": "飲食料",
+      "date": "R5/7/25",
+      "value": 152650,
+      "category": "組織活動費その他",
+      "percentage": 11.742307692307692
+    },
+    {
+      "id": "xxx4",
+      "name": "飲食料",
+      "date": "R5/7/25",
+      "value": 152650,
+      "category": "組織活動費その他",
+      "percentage": 11.742307692307692
+    },
+    {
+      "id": "xxx5",
+      "name": "飲食料",
+      "date": "R5/7/25",
+      "value": 152650,
+      "category": "組織活動費その他",
+      "percentage": 11.742307692307692
+    },
+    {
+      "id": "xxx6",
+      "name": "飲食代",
+      "date": "R5/7/27",
+      "value": 17770,
+      "category": "組織活動費その他",
+      "percentage": 1.366923076923077
+    },
+    {
+      "id": "xxx7",
+      "name": "飲食代",
+      "date": "R5/8/8",
+      "value": 67200,
+      "category": "組織活動費その他",
+      "percentage": 5.1692307692307695
+    },
+    {
+      "id": "xxx8",
+      "name": "食事代",
+      "date": "R5/8/9",
+      "value": 53179,
+      "category": "組織活動費その他",
+      "percentage": 4.090692307692308
+    },
+    {
+      "id": "xxx9",
+      "name": "飲食代",
+      "date": "R5/8/30",
+      "value": 10640,
+      "category": "組織活動費その他",
+      "percentage": 0.8184615384615385
+    },
+    {
+      "id": "xxx10",
+      "name": "食事代",
+      "date": "R5/10/25",
+      "value": 14490,
+      "category": "組織活動費その他",
+      "percentage": 1.1146153846153846
+    },
+    {
+      "id": "xxx11",
+      "name": "飲食料他",
+      "date": "R5/10/30",
+      "value": 45000,
+      "category": "組織活動費その他",
+      "percentage": 3.4615384615384617
+    },
+    {
+      "id": "xxx12",
+      "name": "飲食代＋お土産代",
+      "date": "R5/11/27",
+      "value": 121528,
+      "category": "組織活動費その他",
+      "percentage": 9.348307692307692
+    },
+    {
+      "id": "xxx13",
+      "name": "飲食代",
+      "date": "R5/11/28",
+      "value": 20320,
+      "category": "組織活動費その他",
+      "percentage": 1.563076923076923
+    },
+    {
+      "id": "xxx14",
+      "name": "飲食代",
+      "date": "R5/12/25",
+      "value": 10920,
+      "category": "組織活動費その他",
+      "percentage": 0.84
+    },
+    {
+      "id": "xxx16",
+      "name": "翌年度への繰越",
+      "date": "R5/12/31",
+      "value": 458803,
+      "category": "翌年度への繰越",
+      "percentage": 35.29253846153846
+    }
+  ]
+}


### PR DESCRIPTION
https://w1740803485-clv347541.slack.com/archives/C08FL5L6GSH/p1744618040915549 のもの

- 現サイトは example.ts に書いてある固定のサンプルデータを表示している
- これを実データに切り替えるために、支出報告書から抽出したデータから、可視化用データを作成したい。convert.ts はこの変換処理を（現状ざっくり）実装している
- 使い方：`node --experimental-strip-types generator.ts -i sample_input.json -o sample_output.json`
    - 今は CLI から実行する作りになっているので、抽出→変換→可視化が繋がって動くようにする必要もある
- 入力形式は完全には確定しておらず、データ抽出処理と細部のすり合わせが必要
    - 基本的には `{ year: number, categories: InputCategory[], transactions: InputTransaction[] }` 型のデータがあれば可視化用のデータを作れる
    - transactions の細かい入れ方は、自信ないのでとりあえず決め打ちで validation をたくさん入れてある。すり合わせが必要
        - 「翌年度への繰越」を transaction として明に含むか、transactions には含まずに収支の差から計算するか、等
}`
- 出力形式は example.ts の型に合わせている
    - `{ summary: Summary, flows: Flow[], incomeTransactions: Transaction[], expenseTransactions: Transaction[] }`