### PR TITLE
Update: 支出を表すアイコンを`BanknoteArrowUpIcon`から`BanknoteArrowDownIcon`に変更

### DIFF
--- a/components/BoardTransactions.tsx
+++ b/components/BoardTransactions.tsx
@@ -13,7 +13,7 @@ import {
   Text,
   VStack
 } from '@chakra-ui/react'
-import {BanknoteArrowUpIcon, ChevronLeftIcon, ChevronRightIcon} from 'lucide-react'
+import {BanknoteArrowDownIcon, BanknoteArrowUpIcon, ChevronLeftIcon, ChevronRightIcon} from 'lucide-react'
 import {useState} from 'react'
 import {Transaction} from '@/type'
 
@@ -38,7 +38,13 @@ export function BoardTransactions({direction, transactions}: Props) {
       <Box mb={5}>
         <HStack mb={2}>
           <HStack fontSize={'xl'} fontWeight={'bold'}>
-            <BanknoteArrowUpIcon size={28} className={direction}/>
+            {
+              direction === 'income' ? (
+                <BanknoteArrowUpIcon size={28} className={direction} />
+              ) : (
+                <BanknoteArrowDownIcon size={28} className={direction} />
+              )
+            }
             <Text>{direction === 'income' ? '収入' : '支出'}の一覧</Text>
           </HStack>
         </HStack>


### PR DESCRIPTION
## 変更の概要
支出を表すアイコンを `BanknoteArrowUpIcon` から `BanknoteArrowDownIcon` に変更しました。

Lucide Icons のドキュメントに `BanknoteArrowUpIcon` は主に「収入（income）」、`BanknoteArrowDownIcon` は「支出（expense）」を示す旨の記載があったので、本PRを作成しました。


## 変更箇所のスクリーンショット
| before | after |
| ------ | ----- |
|![image](https://github.com/user-attachments/assets/f2792e28-47b6-49e7-9ba8-94ff9b81940e)        |![image](https://github.com/user-attachments/assets/9a029bdf-0ab8-4cfa-8126-51ee90c7bc7e)       |
|![image](https://github.com/user-attachments/assets/507fa8f0-3131-429f-b267-b2b26b57b7ae)|![image](https://github.com/user-attachments/assets/b4e99407-5288-44d1-897a-a8453c7cc58c)|


## 参照
- [BanknoteArrowUpIcon – Lucide Icons](https://lucide.dev/icons/banknote-arrow-up)
- [BanknoteArrowDownIcon – Lucide Icons](https://lucide.dev/icons/banknote-arrow-down)


---

Polimoney を拝見していて気になった点をPRとして上げさせていただきました。
不要な変更であればそのままクローズいただいて構いません🙇‍♂️
ご確認のほど、よろしくお願いいたします。
