### PR TITLE
jsonスキーマを採用

### DIFF
--- a/tools/analyze_image_gemini.py
+++ b/tools/analyze_image_gemini.py
@@ -152,7 +152,12 @@ categoryの候補
             img = PIL.Image.open(image_path)
             # print("Gemini APIにリクエストを送信中...", file=sys.stderr) # ループ内で冗長なのでコメントアウト
 
-            response = self.model.generate_content([prompt, img])
+            response = self.model.generate_content(
+                contents=[prompt, img],
+                generation_config={
+                    "response_mime_type": "application/json",
+                }
+            )
 
             raw_result = None
             if hasattr(response, 'text') and response.text:


### PR DESCRIPTION
Gemini APIにある、出力をJSONに固定できる機能の実装です。
https://ai.google.dev/gemini-api/docs/structured-output?hl=ja&lang=python

※意図してこれを採用していなかった場合は、このプルリクを消していただいて構いません。

これを採用する場合、
- clean_response (19行目～) がおそらく不要になります。
- まれに出力がjsonにならない（カンマ忘れなど）ことがありますが、数回再試行させるとだいたい直ります。
  - 再試行させるコードを書いてもいいと思います。現状1回問題があると即エラーを出しているようです。
- [出力形式をプロンプトではなくpythonのクラスで指定できます。](https://ai.google.dev/gemini-api/docs/structured-output?hl=ja&lang=python#supply-schema-in-config)プロンプトでも指定可能ですが、こちらのほうがより出力形式が安定します。