### PR TITLE
linterをPR作成時に走らせる設定の追加

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,55 @@
+name: Lint Pull Request
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect package manager
+        id: detect-package-manager
+        run: |
+          if [ -f "${{ github.workspace }}/yarn.lock" ]; then
+            echo "manager=yarn" >> $GITHUB_OUTPUT
+            echo "command=install" >> $GITHUB_OUTPUT
+            echo "runner=yarn" >> $GITHUB_OUTPUT
+            exit 0
+          elif [ -f "${{ github.workspace }}/package.json" ]; then
+            echo "manager=npm" >> $GITHUB_OUTPUT
+            echo "command=ci" >> $GITHUB_OUTPUT
+            echo "runner=npx --no-install" >> $GITHUB_OUTPUT
+            exit 0
+          else
+            echo "Unable to determine package manager"
+            exit 1
+          fi
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: ${{ steps.detect-package-manager.outputs.manager }}
+
+      - name: Restore cache
+        uses: actions/cache@v4
+        with:
+          path: .next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-
+
+      - name: Install dependencies
+        run: |
+          if [ "${{ steps.detect-package-manager.outputs.manager }}" = "npm" ]; then
+            npm ci --legacy-peer-deps
+          else
+            yarn install
+          fi
+
+      - name: Run ESLint
+        run: ${{ steps.detect-package-manager.outputs.runner }} next lint

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,9 @@ import Link from 'next/link'
 import demoTakahiroAnno2024 from '@/data/demo-takahiroanno'
 import demoRyosukeIdei2024 from '@/data/demo-ryosukeidei'
 
+// 未使用の変数を宣言（ESLintエラー: @typescript-eslint/no-unused-vars）
+const unusedVariable = "これは使われていない変数です";
+
 const results = [
   demoTakahiroAnno2024,
   demoRyosukeIdei2024

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,9 +5,6 @@ import Link from 'next/link'
 import demoTakahiroAnno2024 from '@/data/demo-takahiroanno'
 import demoRyosukeIdei2024 from '@/data/demo-ryosukeidei'
 
-// 未使用の変数を宣言（ESLintエラー: @typescript-eslint/no-unused-vars）
-const unusedVariable = "これは使われていない変数です";
-
 const results = [
   demoTakahiroAnno2024,
   demoRyosukeIdei2024


### PR DESCRIPTION
PR作成時にlintの実行漏れに気付けるるようにGitHub Actionsの設定を行いました。
個人のリポジトリでは問題なく実行されることを確認しています。
https://github.com/tdaira/polimoney/pull/1

こちらのリポジトリでは、maintainerの許可が必要なようです。
<img width="634" alt="スクリーンショット 2025-04-30 8 13 05" src="https://github.com/user-attachments/assets/e25ef1f4-7703-4377-bdb3-78efe8a35a09" />

今後の運用としては、mainに向けたPRマージの前にStatus checkでこの設定のチェックを有効にできると、lint漏れが防げると思います
https://docs.github.com/ja/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks
