### PR TITLE
フロントエンド：スキーマ変更２

### DIFF
--- a/app/demo-example/page.tsx
+++ b/app/demo-example/page.tsx
@@ -11,18 +11,18 @@ export default async function Page() {
   return (
     <Box>
       <Header />
-      <BoardSummary profile={data.profile} sources={data.supports} summary={data.summary} flows={data.flows} />
+      <BoardSummary profile={data.profile} report={data.report} otherReports={data.reports} flows={data.flows} />
       <BoardTransactions
         direction={'income'}
-        summary={data.summary}
+        total={data.report.totalIncome}
         transactions={data.transactions.filter(t => t.direction === '収入')}
       />
       <BoardTransactions
         direction={'expense'}
-        summary={data.summary}
+        total={data.report.totalExpense}
         transactions={data.transactions.filter(t => t.direction === '支出')}
       />
-      <BoardMetadata metadata={data.metadata} />
+      <BoardMetadata report={data.report} />
       <Notice />
       <Footer />
     </Box>

--- a/app/demo-ryosuke-idei-2024/page.tsx
+++ b/app/demo-ryosuke-idei-2024/page.tsx
@@ -11,10 +11,10 @@ export default async function Page() {
   return (
     <Box>
       <Header />
-      <BoardSummary profile={data.profile} sources={data.supports} summary={data.summary} flows={data.flows} />
+      <BoardSummary profile={data.profile} report={data.report} otherReports={data.reports} flows={data.flows} />
       <BoardOldTransactions direction={'income'} transactions={data.incomeTransactions} />
       <BoardOldTransactions direction={'expense'} transactions={data.expenseTransactions} />
-      <BoardMetadata metadata={data.metadata} />
+      <BoardMetadata report={data.report} />
       <Notice />
       <Footer />
     </Box>

--- a/app/demo-takahiro-anno-2024/page.tsx
+++ b/app/demo-takahiro-anno-2024/page.tsx
@@ -11,10 +11,10 @@ export default async function Page() {
   return (
     <Box>
       <Header />
-      <BoardSummary profile={data.profile} sources={data.supports} summary={data.summary} flows={data.flows} />
+      <BoardSummary profile={data.profile} report={data.report} otherReports={data.reports} flows={data.flows} />
       <BoardOldTransactions direction={'income'} transactions={data.incomeTransactions} />
       <BoardOldTransactions direction={'expense'} transactions={data.expenseTransactions} />
-      <BoardMetadata metadata={data.metadata} />
+      <BoardMetadata report={data.report} />
       <Notice />
       <Footer />
     </Box>

--- a/components/BoardMetadata.tsx
+++ b/components/BoardMetadata.tsx
@@ -1,12 +1,12 @@
 import {BoardContainer} from '@/components/BoardContainer'
 import {HStack, SimpleGrid, Text} from '@chakra-ui/react'
-import {Metadata} from '@/models/type'
+import {Report} from '@/models/type'
 
 type Props = {
-  metadata: Metadata
+  report: Report
 }
 
-export function BoardMetadata({metadata}: Props) {
+export function BoardMetadata({report}: Props) {
   return (
     <BoardContainer>
       <Text fontSize={'sm'} fontWeight={'bold'} mb={4}>
@@ -15,39 +15,39 @@ export function BoardMetadata({metadata}: Props) {
       <SimpleGrid columns={{base: 1, lg: 2}} gap={2}>
         <HStack>
           <dt>データ引用元</dt>
-          <dd>{metadata.source}</dd>
+          <dd>{report.year}年収支報告書</dd>
         </HStack>
         <HStack>
           <dt>政治団体の区分</dt>
-          <dd>{metadata.orgType}</dd>
+          <dd>{report.orgType}</dd>
         </HStack>
         <HStack>
           <dt>政治団体の名称</dt>
-          <dd>{metadata.orgName}</dd>
+          <dd>{report.orgName}</dd>
         </HStack>
         <HStack>
           <dt>活動区域の区分</dt>
-          <dd>{metadata.activityArea}</dd>
+          <dd>{report.activityArea}</dd>
         </HStack>
         <HStack>
           <dt>代表者</dt>
-          <dd>{metadata.representative}</dd>
+          <dd>{report.representative}</dd>
         </HStack>
         <HStack>
           <dt>資金管理団体の指定</dt>
-          <dd>{metadata.fundManagementOrg}</dd>
+          <dd>{report.fundManagementOrg}</dd>
         </HStack>
         <HStack>
           <dt>会計責任者</dt>
-          <dd>{metadata.accountingManager}</dd>
+          <dd>{report.accountingManager}</dd>
         </HStack>
         <HStack>
           <dt>最終更新日</dt>
-          <dd>{metadata.lastUpdate}</dd>
+          <dd>{report.lastUpdate}</dd>
         </HStack>
         <HStack>
           <dt>事務担当者</dt>
-          <dd>{metadata.administrativeManager}</dd>
+          <dd>{report.administrativeManager}</dd>
         </HStack>
       </SimpleGrid>
     </BoardContainer>

--- a/components/BoardSummary.tsx
+++ b/components/BoardSummary.tsx
@@ -4,17 +4,17 @@ import {BoardContainer} from '@/components/BoardContainer'
 import {Avatar, Badge, Box, HStack, NativeSelect, SimpleGrid, Stack, Stat, Text} from '@chakra-ui/react'
 import {LandmarkIcon} from 'lucide-react'
 import {BoardChart} from '@/components/BoardChart'
-import {Flow, Profile, Summary, Source} from '@/models/type'
+import {Flow, Profile, Report} from '@/models/type'
 import {useRouter} from 'next/navigation'
 
 type Props = {
   profile: Profile
-  sources: Source[]
-  summary: Summary
+  report: Report
+  otherReports: Report[]
   flows: Flow[]
 }
 
-export function BoardSummary({profile, sources, summary, flows}: Props) {
+export function BoardSummary({profile, report, otherReports, flows}: Props) {
 
   const router = useRouter()
   // const [selectedTab, setSelectedTab] = useState('amount')
@@ -45,15 +45,15 @@ export function BoardSummary({profile, sources, summary, flows}: Props) {
           </HStack>
           <NativeSelect.Root
             w={'300px'}
-            defaultValue={sources[0]?.id}
+            defaultValue={report.id}
             onChange={(e) => {
               const target = e.target as HTMLSelectElement
               router.push(`/${target.value}`)
             }}
           >
             <NativeSelect.Field>
-              {sources.map((source) => (
-                <option key={source.id} value={source.id}>{source.year}年 {source.name}</option>
+              {otherReports.map((report) => (
+                <option key={report.id} value={report.id}>{report.year}年 {report.orgName}</option>
               ))}
             </NativeSelect.Field>
             <NativeSelect.Indicator />
@@ -80,7 +80,7 @@ export function BoardSummary({profile, sources, summary, flows}: Props) {
                 fontSize={'sm'}
               >収入総額</Stat.Label>
               <Stat.ValueText alignItems="baseline" fontSize={'2xl'}>
-                {Math.round(summary.income / 10000)}
+                {Math.round(report.totalIncome / 10000)}
                 <Stat.ValueUnit>万円</Stat.ValueUnit>
               </Stat.ValueText>
             </Stat.Root>
@@ -93,7 +93,7 @@ export function BoardSummary({profile, sources, summary, flows}: Props) {
                 fontSize={'sm'}
               >支出総額</Stat.Label>
               <Stat.ValueText alignItems="baseline" fontSize={'2xl'}>
-                {Math.round(summary.expense / 10000)}
+                {Math.round(report.totalExpense / 10000)}
                 <Stat.ValueUnit>万円</Stat.ValueUnit>
               </Stat.ValueText>
             </Stat.Root>
@@ -105,7 +105,7 @@ export function BoardSummary({profile, sources, summary, flows}: Props) {
                 fontSize={'sm'}
               >年間収支</Stat.Label>
               <Stat.ValueText alignItems="baseline" fontSize={'2xl'} >
-                {Math.round(summary.balance / 10000)}
+                {Math.round(report.totalBalance / 10000)}
                 <Stat.ValueUnit>万円</Stat.ValueUnit>
               </Stat.ValueText>
             </Stat.Root>

--- a/components/BoardTransactions.tsx
+++ b/components/BoardTransactions.tsx
@@ -15,20 +15,19 @@ import {
 } from '@chakra-ui/react'
 import {BanknoteArrowDownIcon, BanknoteArrowUpIcon, ChevronLeftIcon, ChevronRightIcon} from 'lucide-react'
 import {useState} from 'react'
-import {Summary, Transaction} from '@/models/type'
+import {Transaction} from '@/models/type'
 
 type Props = {
   direction: 'income' | 'expense'
-  summary: Summary
+  total: number
   transactions: Transaction[]
 }
 
-export function BoardTransactions({direction, summary, transactions}: Props) {
+export function BoardTransactions({direction, total, transactions}: Props) {
 
   // const [selectedTab, setSelectedTab] = useState('name')
   const [page, setPage] = useState(1)
   const pageSize = 10
-  const total = summary[direction]
 
   // 現在のページに表示する transactions を計算
   const sorted = transactions.sort((a, b) => b.amount - a.amount)

--- a/data/demo-example.ts
+++ b/data/demo-example.ts
@@ -1,39 +1,33 @@
-import {Flow, Metadata, Profile, Summary, Source, Transaction} from '@/models/type'
+import {Flow, Profile, Transaction, Report} from '@/models/type'
 
-export const profile: Profile = {
+const profile: Profile = {
   name: 'テスト太郎',
   title: 'テスト党',
   party: 'テスト党',
   image: '/demo-example.png',
 }
 
-export const sources: Source[] = [
+const reports: Report[] = [
   {
     id: 'demo-example',
-    name: 'テストの会',
+    totalIncome: 111111,
+    totalExpense: 100000,
+    totalBalance: 11111,
     year: 2023,
+    orgType: 'その他の政治団体',
+    orgName: 'テストの会',
+    activityArea: '2以上の都道府県の区域等',
+    representative: 'テスト花子',
+    fundManagementOrg: '有/参議院議員(現職)テスト花子',
+    accountingManager: 'テスト花子',
+    administrativeManager: 'テスト花子',
+    lastUpdate: '2024年1月1日',
   }
 ]
 
-export const summary: Summary = {
-  income: 111111,
-  expense: 100000,
-  balance: 11111,
-}
+const report = reports[0]
 
-export const metadata: Metadata = {
-  source: '2023年政治資金収支報告書',
-  orgType: 'その他の政治団体',
-  orgName: 'テストの会',
-  activityArea: '2以上の都道府県の区域等',
-  representative: 'テスト花子',
-  fundManagementOrg: '有/参議院議員(現職)テスト花子',
-  accountingManager: 'テスト花子',
-  administrativeManager: 'テスト花子',
-  lastUpdate: '2024年1月1日',
-}
-
-export const flows: Flow[] = [
+const flows: Flow[] = [
   // 収入
   {id: 'i11', name: '個人からの寄附', direction: 'income', value: 111111, parent: '総収入'},
   {id: 'i99', name: '総収入', direction: 'expense', value: 111111, parent: null},
@@ -44,7 +38,7 @@ export const flows: Flow[] = [
   {id: 'e21', name: '人件費', direction: 'expense', value: 100000, parent: '経常経費'},
 ]
 
-export const transactions: Transaction[] = [
+const transactions: Transaction[] = [
   {
     'id': '7-1-1',
     'direction': '収入',
@@ -68,6 +62,10 @@ export const transactions: Transaction[] = [
 ]
 
 export default {
-  id: 'demo-example',
-  profile, supports: sources, summary, metadata, flows, transactions,
+  id: report.id,
+  profile,
+  report,
+  reports,
+  flows,
+  transactions,
 }

--- a/data/demo-ryosukeidei.ts
+++ b/data/demo-ryosukeidei.ts
@@ -1,6 +1,6 @@
-import {Flow, Metadata, Profile, Summary, Source, OldTransaction} from '@/models/type'
+import {Flow, Profile, OldTransaction, Report} from '@/models/type'
 
-export const profile: Profile = {
+const profile: Profile = {
   name: '出井 良輔',
   title: '自由民主党',
   party: '自由民主党',
@@ -8,33 +8,27 @@ export const profile: Profile = {
   image: '/demo-ryosukeidei.jpg',
 }
 
-export const sources: Source[] = [
+const reports: Report[] = [
   {
     id: 'demo-ryosuke-idei-2024',
-    name: '自由民主党東京都中野区第二十支部',
-    year: 2024
+    totalIncome: 30874279,
+    totalExpense: 29974871,
+    totalBalance: 899408,
+    year: 2024,
+    orgType: '政党の支部',
+    orgName: '自由民主党東京都中野区第二十支部',
+    activityArea: '東京都内',
+    representative: '出井 良輔',
+    fundManagementOrg: '無し',
+    accountingManager: '栢森 高志',
+    administrativeManager: '出井 良輔',
+    lastUpdate: '令和7年2月13日',
   }
 ]
 
-export const summary: Summary = {
-  income: 30874279,
-  expense: 29974871,
-  balance: 899408,
-}
+const report = reports[0]
 
-export const metadata: Metadata = {
-  source: '令和6年政治資金収支報告書',
-  orgType: '政党の支部',
-  orgName: '自由民主党東京都中野区第二十支部',
-  activityArea: '東京都内',
-  representative: '出井 良輔',
-  fundManagementOrg: '無し',
-  accountingManager: '栢森 高志',
-  administrativeManager: '出井 良輔',
-  lastUpdate: '令和7年2月13日',
-}
-
-export const flows: Flow[] = [
+const flows: Flow[] = [
   // 収入
   { id: 'i1', name: '前年からの繰越額', direction: 'income', value: 3406179, parent: '総収入' },
   { id: 'i2', name: '個人の負担する党費又は会費', direction: 'income', value: 251100, parent: '本年の収入額' },
@@ -65,7 +59,7 @@ export const flows: Flow[] = [
   { id: 'e_next', name: '翌年への繰越', direction: 'expense', value: 899408, parent: '総収入' },
 ]
 
-export const incomeTransactions: OldTransaction[] = [
+const incomeTransactions: OldTransaction[] = [
   {
     id: 'i1',
     name: '前年からの繰越額',
@@ -124,7 +118,7 @@ export const incomeTransactions: OldTransaction[] = [
   },
 ]
 
-export const expenseTransactions: OldTransaction[] = [
+const expenseTransactions: OldTransaction[] = [
   {
     id: 'e1',
     name: '人件費',
@@ -208,6 +202,11 @@ export const expenseTransactions: OldTransaction[] = [
 ]
 
 export default {
-  id: 'demo-ryosuke-idei-2024',
-  profile, supports: sources, summary, metadata, flows, incomeTransactions, expenseTransactions,
+  id: report.id,
+  profile,
+  report,
+  reports,
+  flows,
+  incomeTransactions,
+  expenseTransactions,
 }

--- a/data/demo-takahiroanno.ts
+++ b/data/demo-takahiroanno.ts
@@ -1,39 +1,33 @@
-import {Flow, Metadata, Profile, Summary, Source, OldTransaction} from '@/models/type'
+import {Flow, Profile, OldTransaction, Report} from '@/models/type'
 
-export const profile: Profile = {
+const profile: Profile = {
   name: '安野貴博',
   title: 'AIエンジニア',
   party: '無所属',
   image: '/demo-takahiroanno.jpg',
 }
 
-export const sources: Source[] = [
+const reports: Report[] = [
   {
     id: 'demo-takahiro-anno-2024',
-    name: 'デジタル民主主義を考える会',
+    totalIncome: 18416736,
+    totalExpense: 7580065,
+    totalBalance: 10836671,
     year: 2024,
+    orgType: '政治資金規正法第18条の２第１項の規定による政治団体\nその他の政治団体',
+    orgName: 'デジタル民主主義を考える会',
+    activityArea: '東京都内',
+    representative: '安野 貴博',
+    fundManagementOrg: '有り/東京都知事候補 安野貴博',
+    accountingManager: '安野 貴博',
+    administrativeManager: '高山 聡史',
+    lastUpdate: '2024年3月31日',
   }
 ]
 
-export const summary: Summary = {
-  income: 18416736,
-  expense: 7580065,
-  balance: 10836671,
-}
+const report = reports[0]
 
-export const metadata: Metadata = {
-  source: '2024年政治資金収支報告書',
-  orgType: '政治資金規正法第18条の２第１項の規定による政治団体\nその他の政治団体',
-  orgName: 'デジタル民主主義を考える会',
-  activityArea: '東京都内',
-  representative: '安野 貴博',
-  fundManagementOrg: '有り/東京都知事候補 安野貴博',
-  accountingManager: '安野 貴博',
-  administrativeManager: '高山 聡史',
-  lastUpdate: '2024年3月31日',
-}
-
-export const flows: Flow[] = [
+const flows: Flow[] = [
   // 収入
   { id: 'i3', name: '個人からの寄附', direction: 'income', value: 16416736, parent: '総収入' },
   { id: 'i8', name: '借入金', direction: 'income', value: 2000000, parent: '総収入' },
@@ -50,7 +44,7 @@ export const flows: Flow[] = [
   { id: 'e_next', name: '翌年への繰越額', direction: 'expense', value: 10836671, parent: '総収入' },
 ]
 
-export const incomeTransactions: OldTransaction[] = [
+const incomeTransactions: OldTransaction[] = [
   {
     id: '4-1',
     name: '安野貴博',
@@ -69,7 +63,7 @@ export const incomeTransactions: OldTransaction[] = [
   },
 ]
 
-export const expenseTransactions: OldTransaction[] = [
+const expenseTransactions: OldTransaction[] = [
   {
     id: '14-1',
     name: 'コミュニケーションツール費用(slack)',
@@ -145,6 +139,11 @@ export const expenseTransactions: OldTransaction[] = [
 ]
 
 export default {
-  id: 'demo-takahiro-anno-2024',
-  profile, supports: sources, summary, metadata, flows, incomeTransactions, expenseTransactions,
+  id: report.id,
+  profile,
+  report,
+  reports,
+  flows,
+  incomeTransactions,
+  expenseTransactions,
 }

--- a/models/type.d.ts
+++ b/models/type.d.ts
@@ -6,20 +6,12 @@ export type Profile = {
   image: string // 画像URL
 }
 
-export type Source = {
+export type Report = {
   id: string // ID
-  name: string // 支援団体名
+  totalIncome: number // 収入合計
+  totalExpense: number // 支出合計
+  totalBalance: number // 年間収支
   year: number // 対象年
-}
-
-export type Summary = {
-  income: number // 収入合計
-  expense: number // 支出合計
-  balance: number // 年間収支
-}
-
-export type Metadata = {
-  source: string // データ引用元
   orgType: string // 政治団体の区分
   orgName: string // 政治団体の名称
   activityArea: string // 活動区域の区分
@@ -38,15 +30,6 @@ export type Flow = {
   parent: string | null // 親要素のID
 }
 
-export type OldTransaction = {
-  id: string // ID
-  name: string // 項目名
-  category: string // カテゴリー名
-  date: string // 日付
-  value: number // 金額
-  percentage: number // 割合
-}
-
 export type Transaction = {
   id: string
   direction: string
@@ -56,4 +39,14 @@ export type Transaction = {
   name: string
   amount: number
   date: string
+}
+
+// deprecated - Transaction を利用してください
+export type OldTransaction = {
+  id: string // ID
+  name: string // 項目名
+  category: string // カテゴリー名
+  date: string // 日付
+  value: number // 金額
+  percentage: number // 割合
 }


### PR DESCRIPTION
#36 の続きです
Source, Summary, Metadata 型を削除し、Report 型に統合しました
この変更はデータベースのテーブルを以下の３つにするための下準備です

- 政治家一覧を持つ Profiles
- 収支報告書一覧を持つ Reports
- 収支一覧を持つ Transactions
