### PR TITLE
収支報告書の表現に合わせて修正

### DIFF
--- a/data/converter.ts
+++ b/data/converter.ts
@@ -1,5 +1,5 @@
-import * as fs from 'fs'
-import * as path from 'path'
+import * as fs from 'fs';
+import * as path from 'path';
 
 // import { Summary, Flow, Transaction } from '../type';
 type Summary = {
@@ -74,7 +74,7 @@ function convert(data: InputData): OutputData {
     0,
   )
   const nextYearCategory = data.categories.find(
-    (c: InputCategory) => c.name === '翌年度への繰越',
+    (c: InputCategory) => c.name === '翌年への繰越額',
   )
   const balanceTransaction = data.transactions.find(
     (t: InputTransaction) => t.category_id === nextYearCategory?.id,
@@ -180,25 +180,25 @@ function validateInput(data: any): void {
     }
   }
 
-  if (!data.categories.find((c: any) => c.name === '前年度からの繰越')) {
-    throw new Error('カテゴリ「前年度からの繰越」が存在する必要があります')
+  if (!data.categories.find((c: any) => c.name === '前年からの繰越額')) {
+    throw new Error('カテゴリ「前年からの繰越額」が存在する必要があります')
   }
-  if (!data.categories.find((c: any) => c.name === '翌年度への繰越')) {
-    throw new Error('カテゴリ「翌年度への繰越」が存在する必要があります')
+  if (!data.categories.find((c: any) => c.name === '翌年への繰越額')) {
+    throw new Error('カテゴリ「翌年への繰越額」が存在する必要があります')
   }
 
   const previousYearCategory = data.categories.find(
-    (c: any) => c.name === '前年度からの繰越',
+    (c: any) => c.name === '前年からの繰越額',
   )
   const nextYearCategory = data.categories.find(
-    (c: any) => c.name === '翌年度への繰越',
+    (c: any) => c.name === '翌年への繰越額',
   )
   const previousYearTransactions = data.transactions.filter(
     (t: any) => t.category_id === previousYearCategory.id,
   )
   if (previousYearTransactions.length !== 1) {
     throw new Error(
-      '前年度からの繰越の transaction はちょうど1つである必要があります',
+      '前年からの繰越額の transaction はちょうど1つである必要があります',
     )
   }
   const nextYearTransactions = data.transactions.filter(
@@ -206,7 +206,7 @@ function validateInput(data: any): void {
   )
   if (nextYearTransactions.length !== 1) {
     throw new Error(
-      '翌年度への繰越の transaction はちょうど1つである必要があります',
+      '翌年への繰越額の transaction はちょうど1つである必要があります',
     )
   }
 


### PR DESCRIPTION
tsでの表現：翌年度への繰越
gemini & 収支報告書での表現：翌年への繰越額
前年も同様

収支報告書の表記に合わせたほうがGemini出力を流すうえでラクだと思うので、修正させていただきたくPRを書きました。