### PR TITLE
fix pdf downloader: カテゴリ名のより正確な抽出

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -80,6 +80,8 @@ PDFファイル
 ```bash
 # lint
 poetry run ruff check .
+# lint 自動修正あり
+poetry run ruff check --fix .
 # format
 poetry run ruff format .
 # type check

--- a/tools/analyzer/client.py
+++ b/tools/analyzer/client.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import time
 from typing import TYPE_CHECKING, Any, NoReturn, Protocol
 
-import re
 import google.api_core.exceptions
 import google.generativeai as genai
 import PIL.Image
@@ -286,7 +286,7 @@ class GeminiClient:
         image_filename = image_path.name
 
         # ページ番号を特定
-        page_match = re.search(r'_page_(\d+)\.png$', image_filename)
+        page_match = re.search(r"_page_(\d+)\.png$", image_filename)
         page_number_str = page_match.group(1) if page_match else 0
 
         # int型に変換


### PR DESCRIPTION
# 変更の概要
<!-- ここに変更の概要を記載してください -->

 - PDFダウンロード時にファイル名として使うカテゴリ名を間違えることがる不具合の修正

# スクリーンショット
<!-- UIの変更を伴う場合は、変更前後のスクリーンショットもしくはgif画像をこちらに記載してください -->

# 変更の背景
<!-- ここに変更が必要となった背景を記載してください -->

# 関連Issue
<!-- 関連するIssueのリンクをこちらに記載してください -->

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 新しいカテゴリ「資金管理団体」が追加されました。

- **改善**
  - PDFリンクのカテゴリ判定が、より詳細なURL情報に基づいて行われるようになりました。
  - ツールのREADMEに、自動修正付きのリンター実行コマンドが追加されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->