### PR TITLE
analyze_image_gemini.py に並列数をコマンドライン引数で渡せるようにした

### DIFF
--- a/tools/analyze_image_gemini.py
+++ b/tools/analyze_image_gemini.py
@@ -72,6 +72,14 @@ def main() -> None:
         ),
     )
 
+    parser.add_argument(
+        "-w",
+        "--workers",
+        type=int,
+        default=min(32, os.cpu_count() or 1 * 2),
+        help="並列処理を行うスレッド数。",
+    )
+
     args = parser.parse_args()
     api_key = os.getenv("GOOGLE_API_KEY")
     if not api_key:
@@ -125,8 +133,7 @@ def main() -> None:
         )
         return png_file_path, success
 
-    cpu_count = os.cpu_count() or 1
-    max_workers = min(32, cpu_count * 2)
+    max_workers = args.workers
     logger.info("並列処理を開始します (最大 %s スレッド)", max_workers)
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:


### PR DESCRIPTION
# 変更の概要
<!-- ここに変更の概要を記載してください -->

 - analyze_image_gemini.py に並列数をコマンドライン引数で渡せるようにした

# スクリーンショット
<!-- UIの変更を伴う場合は、変更前後のスクリーンショットもしくはgif画像をこちらに記載してください -->

# 変更の背景
<!-- ここに変更が必要となった背景を記載してください -->

# 関連Issue
<!-- 関連するIssueのリンクをこちらに記載してください -->

 - #3 

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 並列処理に使用するスレッド数を指定できる `--workers`（省略形 `-w`）オプションをコマンドライン引数に追加しました。デフォルト値はシステムのCPU数に基づいて自動設定されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->