### PR TITLE
lint error 修正

### DIFF
--- a/components/BoardChart.tsx
+++ b/components/BoardChart.tsx
@@ -97,8 +97,8 @@ const CustomLabelsLayer = ({
           node.label.length * approxCharWidth + textPadding * 2;
         const labelHeight = 30;
         // ノードの右側または左側にラベルを配置するためのオフセット計算
-        let labelX;
-        let labelY;
+        let labelX: number;
+        let labelY: number;
         if (node.id === '総収入') {
           labelX = node.x0 + (nodeWidth - labelWidth) / 2;
           labelY = node.y0 + nodeHeight / 2 - labelHeight / 2;

--- a/data/converter.ts
+++ b/data/converter.ts
@@ -153,7 +153,7 @@ function convert(data: InputData): OutputData {
   };
 }
 
-function validateInput(data: any): string[] {
+function validateInput(data: InputData): string[] {
   const errors: string[] = [];
   if (typeof data.year !== 'number') {
     throw new Error('year は数値である必要があります');
@@ -183,21 +183,25 @@ function validateInput(data: any): string[] {
     }
   }
 
-  if (!data.categories.find((c: any) => c.name === '前年からの繰越額')) {
+  if (
+    !data.categories.find((c: InputCategory) => c.name === '前年からの繰越額')
+  ) {
     throw new Error('カテゴリ「前年からの繰越額」が存在する必要があります');
   }
-  if (!data.categories.find((c: any) => c.name === '翌年への繰越額')) {
+  if (
+    !data.categories.find((c: InputCategory) => c.name === '翌年への繰越額')
+  ) {
     throw new Error('カテゴリ「翌年への繰越額」が存在する必要があります');
   }
 
   const previousYearCategory = data.categories.find(
-    (c: any) => c.name === '前年からの繰越額',
+    (c: InputCategory) => c.name === '前年からの繰越額',
   );
   const nextYearCategory = data.categories.find(
-    (c: any) => c.name === '翌年への繰越額',
+    (c: InputCategory) => c.name === '翌年への繰越額',
   );
   const previousYearTransactions = data.transactions.filter(
-    (t: any) => t.category_id === previousYearCategory.id,
+    (t: InputTransaction) => t.category_id === previousYearCategory?.id,
   );
   if (previousYearTransactions.length !== 1) {
     throw new Error(
@@ -205,7 +209,7 @@ function validateInput(data: any): string[] {
     );
   }
   const nextYearTransactions = data.transactions.filter(
-    (t: any) => t.category_id === nextYearCategory.id,
+    (t: InputTransaction) => t.category_id === nextYearCategory?.id,
   );
   if (nextYearTransactions.length !== 1) {
     throw new Error(
@@ -214,17 +218,17 @@ function validateInput(data: any): string[] {
   }
 
   const incomeCategoryIds = data.categories
-    .filter((c: any) => c.direction === 'income')
-    .map((c: any) => c.id);
+    .filter((c: InputCategory) => c.direction === 'income')
+    .map((c: InputCategory) => c.id);
   const expenseCategoryIds = data.categories
-    .filter((c: any) => c.direction === 'expense')
-    .map((c: any) => c.id);
+    .filter((c: InputCategory) => c.direction === 'expense')
+    .map((c: InputCategory) => c.id);
   const totalIncome = data.transactions
-    .filter((t: any) => incomeCategoryIds.includes(t.category_id))
-    .reduce((sum: number, t: any) => sum + t.value, 0);
+    .filter((t: InputTransaction) => incomeCategoryIds.includes(t.category_id))
+    .reduce((sum: number, t: InputTransaction) => sum + t.value, 0);
   const totalExpense = data.transactions
-    .filter((t: any) => expenseCategoryIds.includes(t.category_id))
-    .reduce((sum: number, t: any) => sum + t.value, 0);
+    .filter((t: InputTransaction) => expenseCategoryIds.includes(t.category_id))
+    .reduce((sum: number, t: InputTransaction) => sum + t.value, 0);
   if (totalIncome !== totalExpense) {
     errors.push(
       `income と expense の合計が一致しません: ${totalIncome} !== ${totalExpense}`,
@@ -232,7 +236,7 @@ function validateInput(data: any): string[] {
   }
 
   const rootCategoryCount = data.categories.filter(
-    (c: any) => !c.parent,
+    (c: InputCategory) => !c.parent,
   ).length;
   if (rootCategoryCount !== 1) {
     errors.push('root category はちょうど1つである必要があります');
@@ -245,13 +249,13 @@ function validateInput(data: any): string[] {
     }
   }
 
-  const categoryIds = data.categories.map((c: any) => c.id);
+  const categoryIds = data.categories.map((c: InputCategory) => c.id);
   const parentCategoryIds = data.categories
-    .map((c: any) => c.parent)
-    .filter((p: any) => p !== null);
+    .map((c: InputCategory) => c.parent)
+    .filter((p: string | null) => p !== null);
   const leafCategoryIds = data.categories
-    .filter((c: any) => !parentCategoryIds.includes(c.id))
-    .map((c: any) => c.id);
+    .filter((c: InputCategory) => !parentCategoryIds.includes(c.id))
+    .map((c: InputCategory) => c.id);
   for (const transaction of data.transactions) {
     if (
       !transaction.id ||

--- a/data/sample_input.json
+++ b/data/sample_input.json
@@ -27,7 +27,7 @@
     },
     {
       "id": "xxx5",
-      "name": "前年度からの繰越",
+      "name": "前年からの繰越額",
       "parent": "xxx66",
       "direction": "income"
     },
@@ -105,7 +105,7 @@
     },
     {
       "id": "xxxh",
-      "name": "翌年度への繰越",
+      "name": "翌年への繰越額",
       "parent": "xxx66",
       "direction": "expense"
     }
@@ -212,14 +212,14 @@
     {
       "id": "xxx15",
       "category_id": "xxx5",
-      "name": "前年度からの繰越",
+      "name": "前年からの繰越額",
       "date": "R5/01/01",
       "value": 1000000
     },
     {
       "id": "xxx16",
       "category_id": "xxxh",
-      "name": "翌年度への繰越",
+      "name": "翌年への繰越額",
       "date": "R5/12/31",
       "value": 458803
     },

--- a/data/sample_output.json
+++ b/data/sample_output.json
@@ -36,7 +36,7 @@
     },
     {
       "id": "xxx5",
-      "name": "前年度からの繰越",
+      "name": "前年からの繰越額",
       "direction": "income",
       "value": 1000000,
       "parent": "xxx66"
@@ -127,7 +127,7 @@
     },
     {
       "id": "xxxh",
-      "name": "翌年度への繰越",
+      "name": "翌年への繰越額",
       "direction": "expense",
       "value": 458803,
       "parent": "xxx66"
@@ -136,10 +136,10 @@
   "incomeTransactions": [
     {
       "id": "xxx15",
-      "name": "前年度からの繰越",
+      "name": "前年からの繰越額",
       "date": "R5/01/01",
       "value": 1000000,
-      "category": "前年度からの繰越",
+      "category": "前年からの繰越額",
       "percentage": 76.92307692307692
     },
     {
@@ -282,10 +282,10 @@
     },
     {
       "id": "xxx16",
-      "name": "翌年度への繰越",
+      "name": "翌年への繰越額",
       "date": "R5/12/31",
       "value": 458803,
-      "category": "翌年度への繰越",
+      "category": "翌年への繰越額",
       "percentage": 35.29253846153846
     }
   ]


### PR DESCRIPTION
# 変更の概要
- lint errorの修正
  - converter.ts のany削除
  - BoardChart.tsx の型追加

# スクリーンショット

- `npm run lint` がwaringなく通ること
<img width="869" alt="image" src="https://github.com/user-attachments/assets/a6b55888-bbde-41da-8045-b049a1b09231" />

- `npx tsx data/converter.ts -i data/sample_input.json -o data/sample_output.json` が通ること
<img width="869" alt="スクリーンショット 2025-05-24 18 59 03" src="https://github.com/user-attachments/assets/72f47ef5-c44b-4ebf-8bf8-63af1f6b5da4" />

# 変更の背景
https://github.com/digitaldemocracy2030/polimoney/issues/79

# 関連Issue
https://github.com/digitaldemocracy2030/polimoney/issues/79

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **ドキュメント**
  - サンプルデータ内のカテゴリ名および取引名を「前年度からの繰越」から「前年からの繰越額」、「翌年度への繰越」から「翌年への繰越額」へ統一しました。

- **リファクタ**
  - 入力データ検証機能の型安全性が向上しました（TypeScript型の明示化）。
  - 一部内部変数に型注釈を追加し、コードの堅牢性を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->