### PR TITLE
PDFから画像への変換処理に画像前処理機能を追加

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -101,9 +101,10 @@ poetry run pyright .
 
 2.  **PDFを画像に変換**:
     ```bash
-    python pdf_to_images.py <your_document.pdf> -o output_images
+    python pdf_to_images.py <your_document.pdf> -o output_images --preprocess grayscale binarize
     ```
-    これにより、`output_images` ディレクトリに `your_document_page_001.png`, `your_document_page_002.png`, ... が生成されます。
+    これにより、`output_images` ディレクトリに `your_document_page_001.png`, `your_document_page_002.png`, ... が生成されます。  
+    `--preprocess` オプションを指定すると、変換後に画像の前処理を行い、結果を `output_images/processed` に保存します。
 
 3.  **画像を解析してJSONを生成**:
     *   **単一の画像ファイル**:

--- a/tools/preprocess.py
+++ b/tools/preprocess.py
@@ -1,0 +1,52 @@
+"""Basic image preprocessing utilities."""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterable
+from pathlib import Path
+
+from PIL import Image, ImageFilter, ImageOps
+
+logger = logging.getLogger("preprocess")
+
+
+class ImagePreprocessor:
+    """Apply simple preprocessing steps to images."""
+
+    AVAILABLE_STEPS = {"grayscale", "binarize", "denoise"}
+
+    def __init__(self, steps: Iterable[str]) -> None:
+        self.steps: list[str] = list(steps)
+        invalid = [s for s in self.steps if s not in self.AVAILABLE_STEPS]
+        if invalid:
+            raise ValueError(f"Unknown preprocessing steps: {invalid}")
+
+    def apply(self, image: Image.Image) -> Image.Image:
+        result = image
+        for step in self.steps:
+            if step == "grayscale":
+                result = ImageOps.grayscale(result)
+            elif step == "binarize":
+                if result.mode != "L":
+                    result = ImageOps.grayscale(result)
+                result = result.point(lambda x: 0 if x < 128 else 255, "1")
+            elif step == "denoise":
+                result = result.filter(ImageFilter.MedianFilter(size=3))
+        return result
+
+    def process_file(self, input_path: Path, output_dir: Path) -> Path:
+        image = Image.open(input_path)
+        processed = self.apply(image)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        output_path = output_dir / input_path.name
+        processed.save(output_path)
+        logger.info("Saved preprocessed image: %s", output_path)
+        return output_path
+
+
+def save_log(path: Path, entries: list[dict]) -> None:
+    """Save preprocessing log as JSON."""
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(entries, f, ensure_ascii=False, indent=2)


### PR DESCRIPTION
# 変更の概要
画像の前処理を行う preprocess.pyモジュールを追加
処理内容は「グレースケール化」「二値化」「ノイズ除去」
pdf_to_images.py に --preprocess オプションを実装
前処理済み画像は output_images/processed に保存し、実行内容を preprocess_log.json に記録

# 変更の背景
前処理することによってより安定した高いOCR認識精度を達成するため

# 関連Issue
<https://github.com/digitaldemocracy2030/polimoney/issues/95>

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
