### PR TITLE
レポートページの追加(コミット漏れ)

### DIFF
--- a/app/reports/[id]/page.tsx
+++ b/app/reports/[id]/page.tsx
@@ -1,0 +1,93 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { BoardMetadata } from '@/components/BoardMetadata';
+import { BoardSummary } from '@/components/BoardSummary';
+import { BoardTransactions } from '@/components/BoardTransactions';
+import { Footer } from '@/components/Footer';
+import { Header } from '@/components/Header';
+import { Notice } from '@/components/Notice';
+import type { Flow, Profile, Report, Transaction } from '@/models/type';
+import { Box } from '@chakra-ui/react';
+import { notFound } from 'next/navigation';
+
+interface ReportData {
+  id: string;
+  profile: Profile;
+  report: Report;
+  reports: Report[];
+  flows: Flow[];
+  incomeTransactions: Transaction[];
+  expenseTransactions: Transaction[];
+}
+
+async function getReportData(id: string): Promise<ReportData | null> {
+  try {
+    const filePath = path.join(
+      process.cwd(),
+      'public',
+      'reports',
+      `${id}.json`,
+    );
+    const fileContents = fs.readFileSync(filePath, 'utf8');
+    return JSON.parse(fileContents);
+  } catch (error) {
+    console.error('Error loading report data:', error);
+    return null;
+  }
+}
+
+export async function generateStaticParams() {
+  const reportsDirectory = path.join(process.cwd(), 'public', 'reports');
+
+  try {
+    const filenames = fs.readdirSync(reportsDirectory);
+
+    return filenames
+      .filter((name) => name.endsWith('.json'))
+      .map((name) => ({
+        id: name.replace('.json', ''),
+      }));
+  } catch (error) {
+    console.error('Error reading reports directory:', error);
+    return [];
+  }
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const data = await getReportData(id);
+
+  if (!data) {
+    notFound();
+  }
+
+  return (
+    <Box>
+      <Header />
+      <BoardSummary
+        profile={data.profile}
+        report={data.report}
+        otherReports={data.reports}
+        flows={data.flows}
+        useFixedBoardChart={true}
+      />
+      <BoardTransactions
+        direction={'income'}
+        total={data.report.totalIncome}
+        transactions={data.incomeTransactions}
+      />
+      <BoardTransactions
+        direction={'expense'}
+        total={data.report.totalExpense}
+        transactions={data.expenseTransactions}
+      />
+      <BoardMetadata report={data.report} />
+      <Notice />
+      <Footer />
+    </Box>
+  );
+}


### PR DESCRIPTION
# 変更の概要
<!-- ここに変更の概要を記載してください -->

 - #115 のコミット漏れです。一番大事なファイルが抜けてました。。。

# スクリーンショット
<!-- UIの変更を伴う場合は、変更前後のスクリーンショットもしくはgif画像をこちらに記載してください -->

# 変更の背景
<!-- ここに変更が必要となった背景を記載してください -->

# 関連Issue
<!-- 関連するIssueのリンクをこちらに記載してください -->

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - レポートIDに基づき動的にレポートを表示する新しいページを追加しました。
  - レポートデータの取得に失敗した場合は404ページが表示されます。
  - レポートにはヘッダー、サマリーボード、収入・支出のトランザクションボード、メタデータ、注意事項、フッターが含まれます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->