### PR TITLE
PDFからWeb表示用のJSONを作成するシェルスクリプトの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ npm install --legacy-peer-deps
 npm run dev
 ```
 
+### PDFからWeb表示用のJSONを作成
+
+** 前提条件 **
+
+ - tools/README.md を参照して、Pythonの環境をセットアップしておく。
+ - 環境変数 GOOGLE_API_KEY を設定しておく。
+
+```bash
+./scripts/create-json-for-web.sh hoge.pdf ./public/reports/hoge.json
+```
+
 ### データ処理ツール
 
 - **Python**

--- a/data/converter.ts
+++ b/data/converter.ts
@@ -46,6 +46,7 @@ type OutputDataOld = {
 
 type BasicInfo = {
   orgName: string;
+  orgType: string;
   activityArea: string;
   representative: string;
   fundManagementOrg: string;
@@ -170,30 +171,31 @@ function convert(data: InputData): OutputData {
   if (rootFlow) {
     rootFlow.value /= 2;
   }
+  const report: Report = {
+    id: 'TODO',
+    totalIncome: totalIncome,
+    totalExpense: totalExpense,
+    totalBalance: balanceTransaction ? balanceTransaction.value : 0,
+    year: data.year,
+    orgType: data.basic_info.orgType,
+    orgName: data.basic_info.orgName,
+    activityArea: data.basic_info.activityArea,
+    representative: data.basic_info.representative,
+    fundManagementOrg: data.basic_info.fundManagementOrg,
+    accountingManager: data.basic_info.accountingManager,
+    administrativeManager: data.basic_info.administrativeManager,
+    lastUpdate: data.basic_info.lastUpdate,
+  };
 
   return {
     profile: {
-      name: 'テスト太郎',
-      title: 'テスト党',
-      party: 'テスト党',
+      name: data.basic_info.representative,
+      title: data.basic_info.representative,
+      party: data.basic_info.orgName,
       image: '/demo-example.png',
     },
-    report: {
-      id: 'TODO',
-      totalIncome: totalIncome,
-      totalExpense: totalExpense,
-      totalBalance: balanceTransaction ? balanceTransaction.value : 0,
-      year: data.year,
-      orgType: 'TODO',
-      orgName: data.basic_info.orgName,
-      activityArea: data.basic_info.activityArea,
-      representative: data.basic_info.representative,
-      fundManagementOrg: data.basic_info.fundManagementOrg,
-      accountingManager: data.basic_info.accountingManager,
-      administrativeManager: data.basic_info.administrativeManager,
-      lastUpdate: data.basic_info.lastUpdate,
-    },
-    reports: [],
+    report: report,
+    reports: [report],
     flows,
     incomeTransactions,
     expenseTransactions,

--- a/scripts/create-json-for-web.sh
+++ b/scripts/create-json-for-web.sh
@@ -24,12 +24,13 @@ fi
 cd $(dirname $(dirname $(realpath $0)))
 
 work_dir=
-while getopts "i:o:" opt; do
+while getopts "w:" opt; do
     case $opt in
         w) work_dir=$OPTARG ;;
         *) echo "Usage: $0 [-d work_dir] <pdf_path> <output_json_path>" ;;
     esac
 done
+shift $((OPTIND - 1))
 
 pdf_path=$1
 output_json_path=$2
@@ -44,6 +45,7 @@ echo "images dir: $tmpdir_image"
 echo "json dir: $tmpdir_json"
 
 # PDF => Images
+echo python tools/pdf_to_images.py -o $tmpdir_image $pdf_path
 python tools/pdf_to_images.py -o $tmpdir_image $pdf_path
 # Images => JSON Files
 python tools/analyze_image_gemini.py -i $tmpdir_image -o $tmpdir_json

--- a/scripts/create-json-for-web.sh
+++ b/scripts/create-json-for-web.sh
@@ -1,0 +1,55 @@
+#!/bin/bash -ue
+# PDFからWeb表示用のJSONを作成するスクリプト
+#
+# 使用方法:
+#   ./scripts/create-json-for-web.sh [-w work_dir] pdf_path output_json_path
+#
+# 使用例:
+#   ./scripts/create-json-for-web.sh hoge.pdf ./public/reports/hoge.json
+#
+# パラメータ:
+#   pdf_path: PDFファイルのパス
+#   output_json_path: 出力JSONファイルのパス
+#
+# オプション:
+#   -w work_dir: 作業ディレクトリを指定する (デフォルト: 一時ディレクトリ)
+
+# check if poetry is installed
+if ! command -v poetry &> /dev/null; then
+    echo "poetry could not be found"
+    exit 1
+fi
+
+# cd to parent directory of this script
+cd $(dirname $(dirname $(realpath $0)))
+
+work_dir=
+while getopts "i:o:" opt; do
+    case $opt in
+        w) work_dir=$OPTARG ;;
+        *) echo "Usage: $0 [-d work_dir] <pdf_path> <output_json_path>" ;;
+    esac
+done
+
+pdf_path=$1
+output_json_path=$2
+
+if [[ -z "$work_dir" ]]; then
+    work_dir=$(mktemp -d)
+fi
+
+tmpdir_image=$work_dir/images
+tmpdir_json=$work_dir/jsons
+echo "images dir: $tmpdir_image"
+echo "json dir: $tmpdir_json"
+
+# PDF => Images
+python tools/pdf_to_images.py -o $tmpdir_image $pdf_path
+# Images => JSON Files
+python tools/analyze_image_gemini.py -i $tmpdir_image -o $tmpdir_json
+# JSON Files => Merged JSON File
+merge_json_file=$work_dir/merged.json
+python tools/merge_jsons.py -i $tmpdir_json -o $merge_json_file
+
+# Merged JSON File => JSON File for Web
+npx tsx data/converter.ts -i $merge_json_file -o $output_json_path --ignore-errors

--- a/tools/README.md
+++ b/tools/README.md
@@ -32,7 +32,7 @@ PDFファイル
 
 ## 必要なもの
 
-*   **Python**: 3.8 以上推奨
+*   **Python**: 3.10 以上推奨
 *   **Poppler**: `pdf2image` がPDFを処理するために必要です。
     *   **macOS**: `brew install poppler`
     *   **Debian/Ubuntu**: `sudo apt-get update && sudo apt-get install -y poppler-utils`
@@ -113,7 +113,7 @@ poetry run pyright .
         ```
     *   **ディレクトリ内の全PNG画像**:
         ```bash
-        python analyze_image_gemini.py -d output_images -o output_json
+        python analyze_image_gemini.py -i output_images -o output_json
         ```
     これにより、`output_json` ディレクトリに `your_document_page_001.json`, `your_document_page_002.json`, ... が生成されます。
 

--- a/tools/analyze_image_gemini.py
+++ b/tools/analyze_image_gemini.py
@@ -58,8 +58,8 @@ def main() -> None:
         help="解析する単一の画像ファイルのパス。",
     )
     input_group.add_argument(
-        "-d",
-        "--directory",
+        "-i",
+        "--input",
         help="解析するPNG画像が含まれるディレクトリのパス。",
     )
 
@@ -107,7 +107,7 @@ def main() -> None:
 
     # 処理対象のPNGファイルを取得
     try:
-        directory = Path(args.directory) if args.directory else None
+        directory = Path(args.input) if args.input else None
         image_file = Path(args.image_file) if args.image_file else None
         png_files = ImageProcessor.get_png_files_to_process(directory, image_file)
     except ValueError:

--- a/tools/merge_jsons.py
+++ b/tools/merge_jsons.py
@@ -315,39 +315,39 @@ def remove_empty_categories(all_json):
 def main():
     parser = argparse.ArgumentParser(description="JSONファイルをマージしてall.jsonを作成します")
     parser.add_argument(
-        "-t",
-        "--target-dir",
+        "-i",
+        "--input",
         default=os.path.join(os.getcwd(), "output_json"),
         help="マージするJSONファイルがあるディレクトリ (デフォルト: ./output_json)",
     )
     parser.add_argument(
-        "-m",
-        "--merged-dir",
-        default=os.path.join(os.getcwd(), "tools", "merged_files"),
-        help="マージしたall.jsonを保存するディレクトリ (デフォルト: ./tools/merged_files)",
+        "-o",
+        "--output",
+        default=os.path.join(os.getcwd(), "tools", "merged_files", "all.json"),
+        help="マージしたall.jsonを保存するファイル (デフォルト: ./tools/merged_files/all.json)",
     )
 
     args = parser.parse_args()
 
-    target_dir = args.target_dir
-    merged_dir = args.merged_dir
+    input_dir = args.input
+    output_path = args.output
 
     # ディレクトリが存在しない場合は作成
-    os.makedirs(merged_dir, exist_ok=True)
+    dirname = os.path.dirname(output_path)
+    os.makedirs(dirname, exist_ok=True)
 
-    file_paths = glob.glob(os.path.join(target_dir, "*.json"))
+    file_paths = glob.glob(os.path.join(input_dir, "*.json"))
 
     file_paths = sorted(file_paths)
     print(f"対象ファイル: {file_paths}")
 
     if not file_paths:
-        print(f"警告: {target_dir} にJSONファイルが見つかりませんでした")
+        print(f"警告: {input_dir} にJSONファイルが見つかりませんでした")
         return
 
     all_json = load_all_json(file_paths)
     all_json = fix_duplicate_categories(all_json)
 
-    output_path = os.path.join(merged_dir, "all.json")
     with open(output_path, "w", encoding="utf-8") as f:
         json.dump(all_json, f, ensure_ascii=False, indent=2)
 


### PR DESCRIPTION
# 変更の概要
<!-- ここに変更の概要を記載してください -->

 - 表題の通りです。 ./scripts/create-json-for-web.sh で PDF => Web用JSON を実行できます。

```
# 下記が成功すれば /reports/hoge でWebからデータが見れます。
./scripts/create-json-for-web.sh hoge.pdf ./public/reports/hoge.json
```

# スクリーンショット
<!-- UIの変更を伴う場合は、変更前後のスクリーンショットもしくはgif画像をこちらに記載してください -->

# 変更の背景
<!-- ここに変更が必要となった背景を記載してください -->

# 関連Issue
<!-- 関連するIssueのリンクをこちらに記載してください -->

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - PDFファイルをWeb表示用JSONに変換する新しいスクリプトを追加しました。

- **ドキュメント**
  - READMEにPDFからWeb表示用JSONを作成する手順を追加しました。
  - Pythonの必要バージョンを3.10に更新し、画像解析コマンドのオプション説明を修正しました。

- **バグ修正**
  - 画像解析・JSONマージ用スクリプトのコマンドライン引数名をより分かりやすいものに変更しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->