### PR TITLE
コピー機能がモバイル画面で表示されないように修正

### DIFF
--- a/components/BoardSummary.tsx
+++ b/components/BoardSummary.tsx
@@ -217,7 +217,11 @@ export function BoardSummary({
       ) : (
         <BoardChart flows={flows} />
       )}
-      <Box mb={3} display="flex" justifyContent="flex-end">
+      <Box
+        mb={3}
+        display={{ base: 'none', md: 'flex' }}
+        justifyContent="flex-end"
+      >
         <button
           type="button"
           id="copy-image-btn"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2642,9 +2642,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
# 変更の概要
モバイル画面では表示されないように修正しました

# スクリーンショット
<!-- UIの変更を伴う場合は、変更前後のスクリーンショットもしくはgif画像をこちらに記載してください -->

# 変更の背景
iphoneで画像コピーを試みましたが失敗しました。
モバイル画面ではサンキー図がスクロール表示されているため画像コピーしても途中で途切れてしまいました。

# 関連Issue
<!-- 関連するIssueのリンクをこちらに記載してください -->

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイル**
  - コピー画像ボタンが小さい画面サイズでは非表示になり、中〜大画面サイズでのみ表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->