### PR TITLE
refs #102 準備中のComing Soon...パネルを追加

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,10 @@
 import { Footer } from '@/components/Footer';
 import { Header } from '@/components/Header';
 import { Notice } from '@/components/Notice';
+import demoComingsoon, {
+  comingSoonId,
+  comingSoonNum,
+} from '@/data/demo-comingsoon';
 import demoExample from '@/data/demo-example';
 import demoKokiFujisaki from '@/data/demo-kokifujisaki';
 import demoRyosukeIdei from '@/data/demo-ryosukeidei';
@@ -22,6 +26,11 @@ const results = [
   demoRyosukeIdei,
   demoKokiFujisaki,
   demoExample,
+  ...Array.from({ length: comingSoonNum }, (_, i) => ({
+    ...demoComingsoon,
+    id: `${comingSoonId}-${i}`,
+    latestReportId: `${comingSoonId}-${i}`,
+  })),
 ];
 
 export const metadata = {
@@ -36,15 +45,27 @@ export default function Page() {
       <Header />
       <SimpleGrid columns={{ base: 1, lg: 2 }} gap={5} mb={5} p={2}>
         {results.map((result) => (
-          <Link href={`/${result.latestReportId}`} key={result.latestReportId}>
-            <Card.Root flexDirection={'row'} boxShadow={'xs'} border={'none'}>
+          <Link
+            href={
+              !result.latestReportId.startsWith(comingSoonId)
+                ? `/${result.latestReportId}`
+                : '#'
+            }
+            key={result.latestReportId}
+          >
+            <Card.Root
+              flexDirection={'row'}
+              boxShadow={'xs'}
+              border={'none'}
+              alignItems={'center'}
+            >
               <Image
-                objectFit="cover"
-                maxW="130px"
+                objectFit={'cover'}
+                maxW={'130px'}
                 src={result.profile.image}
                 alt={result.profile.name}
-                borderTopLeftRadius="md"
-                borderBottomLeftRadius="md"
+                borderTopLeftRadius={'md'}
+                borderBottomLeftRadius={'md'}
               />
               <Box>
                 <Card.Body>
@@ -54,9 +75,11 @@ export default function Page() {
                       {result.profile.name}
                     </Text>
                     <HStack mt={1}>
-                      <Badge variant={'outline'} colorPalette={'red'}>
-                        {result.profile.party}
-                      </Badge>
+                      {result.profile.party && (
+                        <Badge variant={'outline'} colorPalette={'red'}>
+                          {result.profile.party}
+                        </Badge>
+                      )}
                       {result.profile.district && (
                         <Badge variant={'outline'}>
                           {result.profile.district}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -60,34 +60,34 @@ export default function Page() {
             key={entry.latestReportId}
           >
             <Card.Root
-              flexDirection={'row'}
-              boxShadow={'xs'}
-              border={'none'}
-              alignItems={'center'}
+              flexDirection="row"
+              boxShadow="xs"
+              border="none"
+              alignItems="center"
             >
               <Image
-                objectFit={'cover'}
-                maxW={'130px'}
+                objectFit="cover"
+                maxW="130px"
                 src={entry.profile.image}
                 alt={entry.profile.name}
-                borderTopLeftRadius={'md'}
-                borderBottomLeftRadius={'md'}
+                borderTopLeftRadius="md"
+                borderBottomLeftRadius="md"
               />
               <Box>
                 <Card.Body>
                   <Stack gap={0}>
-                    <Text fontSize={'xs'}>{entry.profile.title}</Text>
-                    <Text fontSize={'2xl'} fontWeight={'bold'}>
+                    <Text fontSize="xs">{entry.profile.title}</Text>
+                    <Text fontSize="2xl" fontWeight="bold">
                       {entry.profile.name}
                     </Text>
                     <HStack mt={1}>
                       {entry.profile.party && (
-                        <Badge variant={'outline'} colorPalette={'red'}>
+                        <Badge variant="outline" colorPalette="red">
                           {entry.profile.party}
                         </Badge>
                       )}
                       {entry.profile.district && (
-                        <Badge variant={'outline'}>
+                        <Badge variant="outline">
                           {entry.profile.district}
                         </Badge>
                       )}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,6 +9,7 @@ import demoExample from '@/data/demo-example';
 import demoKokiFujisaki from '@/data/demo-kokifujisaki';
 import demoRyosukeIdei from '@/data/demo-ryosukeidei';
 import demoTakahiroAnno from '@/data/demo-takahiroanno';
+import type { ProfileList } from '@/models/type';
 import {
   Badge,
   Box,
@@ -21,7 +22,12 @@ import {
 } from '@chakra-ui/react';
 import Link from 'next/link';
 
-const results = [
+type Entry = {
+  id: string;
+  latestReportId: string;
+  profile: ProfileList;
+};
+const entries: Entry[] = [
   demoTakahiroAnno,
   demoRyosukeIdei,
   demoKokiFujisaki,
@@ -44,14 +50,14 @@ export default function Page() {
     <Box>
       <Header />
       <SimpleGrid columns={{ base: 1, lg: 2 }} gap={5} mb={5} p={2}>
-        {results.map((result) => (
+        {entries.map((entry) => (
           <Link
             href={
-              !result.latestReportId.startsWith(comingSoonId)
-                ? `/${result.latestReportId}`
+              !entry.latestReportId.startsWith(comingSoonId)
+                ? `/${entry.latestReportId}`
                 : '#'
             }
-            key={result.latestReportId}
+            key={entry.latestReportId}
           >
             <Card.Root
               flexDirection={'row'}
@@ -62,27 +68,27 @@ export default function Page() {
               <Image
                 objectFit={'cover'}
                 maxW={'130px'}
-                src={result.profile.image}
-                alt={result.profile.name}
+                src={entry.profile.image}
+                alt={entry.profile.name}
                 borderTopLeftRadius={'md'}
                 borderBottomLeftRadius={'md'}
               />
               <Box>
                 <Card.Body>
                   <Stack gap={0}>
-                    <Text fontSize={'xs'}>{result.profile.title}</Text>
+                    <Text fontSize={'xs'}>{entry.profile.title}</Text>
                     <Text fontSize={'2xl'} fontWeight={'bold'}>
-                      {result.profile.name}
+                      {entry.profile.name}
                     </Text>
                     <HStack mt={1}>
-                      {result.profile.party && (
+                      {entry.profile.party && (
                         <Badge variant={'outline'} colorPalette={'red'}>
-                          {result.profile.party}
+                          {entry.profile.party}
                         </Badge>
                       )}
-                      {result.profile.district && (
+                      {entry.profile.district && (
                         <Badge variant={'outline'}>
-                          {result.profile.district}
+                          {entry.profile.district}
                         </Badge>
                       )}
                     </HStack>

--- a/data/demo-comingsoon.ts
+++ b/data/demo-comingsoon.ts
@@ -1,0 +1,14 @@
+import type { ProfileList } from '@/models/type';
+export const comingSoonNum = 1;
+export const comingSoonId = 'demo-comingsoon';
+
+const profile: ProfileList = {
+  name: 'Coming Soon...',
+  image: '/demo-example.png',
+};
+
+export default {
+  id: comingSoonId,
+  latestReportId: comingSoonId,
+  profile,
+};

--- a/models/type.d.ts
+++ b/models/type.d.ts
@@ -5,6 +5,9 @@ export type Profile = {
   district?: string; // 選挙区
   image: string; // 画像URL
 };
+// 政治家一覧表示用
+export type ProfileList = Pick<Profile, 'name' | 'image'> &
+  Partial<Omit<Profile, 'name' | 'image'>>;
 
 export type Report = {
   id: string; // ID


### PR DESCRIPTION
# 変更の概要

- Comming Soon...パネルを追加
  - リンク先はないためパネルをクリックしても遷移しない（既存のパネルは変わらず遷移できる）
  - 画像は `demo-example.png` をとりあえず設定
  - パネルの数は任意の数に変更できる
    - ハードコーディングしたのでDBから取得するようにするなどの検討の余地あり
- リファクタリング
  - 変数名の修正
  - 型付け
  - 静的な属性値を文字列に変更

# スクリーンショット

| 変更前 | 変更後 |
| ------- | ------- |
| <img width="960" alt="image" src="https://github.com/user-attachments/assets/0515bd64-dda4-4364-a141-7f4d35cc748a" /> | <img width="959" alt="image" src="https://github.com/user-attachments/assets/f28bf2ad-4852-4319-8e36-37cfd1313985" /> |

- 任意の数にすることができる

| 0 | 1 | 3 | 
| ------- | ------- | ------- |
|  <img width="957" alt="image" src="https://github.com/user-attachments/assets/02fbf95a-e6fb-4293-adf8-96b0ac8e748a" /> | <img width="959" alt="image" src="https://github.com/user-attachments/assets/5416d62c-b5a1-42f9-b856-c6917dfef73f" /> | <img width="480" alt="image" src="https://github.com/user-attachments/assets/e714dd69-1f4f-4a0e-94ad-819fe976f194" /> |

# 変更の背景
#102 

# 関連Issue
#102 

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 「近日公開」プロファイルのプレースホルダーが一覧に動的に表示されるようになりました。

- **改善**
  - プロファイルカードのレイアウトが中央揃えになり、バッジの表示が条件付きでより分かりやすくなりました。
  - プロファイル一覧のリンク先が条件によって適切に制御されるようになりました。

- **スタイル**
  - JSXのプロパティ表記が統一され、コードの一貫性が向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->