### PR TITLE
feat: レポート選択プルダウンを年で降順ソートする機能を追加

### DIFF
--- a/components/BoardSummary.tsx
+++ b/components/BoardSummary.tsx
@@ -43,11 +43,11 @@ export function BoardSummary({
     ? pathname.slice(1)
     : pathname;
 
-  // 全てのレポート（現在のレポートと他のレポート）を結合（重複除去）
+  // 全てのレポート（現在のレポートと他のレポート）を結合（重複除去）し、年で降順ソート
   const allReports = [
     report,
     ...otherReports.filter((r) => r.id !== report.id),
-  ];
+  ].sort((a, b) => b.year - a.year);
   const handleCopyImage = async () => {
     const button = document.getElementById('copy-image-btn');
     if (button) button.style.display = 'none'; // ボタンを非表示


### PR DESCRIPTION
# 変更の概要
<!-- ここに変更の概要を記載してください -->
- レポート選択プルダウンメニューでレポートが順不同で表示されていたため、直感的な並び順（年の降順）に修正

# スクリーンショット
<!-- UIの変更を伴う場合は、変更前後のスクリーンショットもしくはgif画像をこちらに記載してください -->
変更前
<img width="1101" height="173" alt="スクリーンショット 2025-07-14 21 59 39" src="https://github.com/user-attachments/assets/ca4aa101-39c1-443c-805e-033fdbb78efd" />
変更後
<img width="1114" height="167" alt="スクリーンショット 2025-07-14 21 59 11" src="https://github.com/user-attachments/assets/54cc3c51-8db8-4135-817f-e5414d780d7b" />

# 変更の背景
<!-- ここに変更が必要となった背景を記載してください -->

- レポート選択プルダウンメニューでレポートが順不同で表示されていたため、特定の年のレポートを探す際に手間がかかる問題が発生していた。
- 特に最新のレポートを優先的に確認したいユーザーにとって、直感的な並び順（新しい年から古い年の順）が求められていた。

# 関連Issue
<!-- 関連するIssueのリンクをこちらに記載してください -->

#150 

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * レポート一覧の表示順が年順（降順）に並ぶようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->