### PR TITLE
add preview page

### DIFF
--- a/app/preview/page.tsx
+++ b/app/preview/page.tsx
@@ -1,0 +1,30 @@
+import { Alert, Box } from '@chakra-ui/react';
+import { Footer } from '@/components/Footer';
+import { Header } from '@/components/Header';
+import { Notice } from '@/components/Notice';
+import { PreviewBoard } from '@/components/PreviewBoard';
+
+export default function Page() {
+  return (
+    <Box>
+      <Header />
+      <PreviewAlert />
+      <PreviewBoard />
+      <Notice />
+      <Footer />
+    </Box>
+  );
+}
+
+function PreviewAlert() {
+  return <>
+    <Alert.Root status="warning">
+      <Alert.Indicator />
+      <Alert.Content>
+        <Alert.Description>
+          このページの内容は公開前のものです。URLを知っている人しかアクセスできません。
+        </Alert.Description>
+      </Alert.Content>
+    </Alert.Root>
+  </>
+}

--- a/components/Board.tsx
+++ b/components/Board.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { BoardMetadata } from '@/components/BoardMetadata';
+import { BoardSummary } from '@/components/BoardSummary';
+import { BoardTransactions } from '@/components/BoardTransactions';
+import type { AccountingReports } from '@/models/type';
+
+interface BoardProps {
+  data: AccountingReports | null;
+}
+
+export function Board({ data }: BoardProps) {
+  if (!data) return <></>;
+
+  const reportData = data.datas.find(
+    (d) => d.report.id === data.latestReportId,
+  );
+  if (!reportData) return null;
+  return (
+    <>
+      <BoardSummary
+        profile={data.profile}
+        report={reportData.report}
+        otherReports={data.datas.map((d) => d.report)}
+        flows={reportData.flows}
+        useFixedBoardChart={false}
+      />
+      <BoardTransactions
+        direction={'income'}
+        total={reportData.report.totalIncome}
+        transactions={reportData.transactions.filter(
+          (t) => t.direction === 'income',
+        )}
+        showPurpose={true}
+        showDate={true}
+      />
+      <BoardTransactions
+        direction={'expense'}
+        total={reportData.report.totalExpense}
+        transactions={reportData.transactions.filter(
+          (t) => t.direction === 'expense',
+        )}
+        showPurpose={true}
+        showDate={true}
+      />
+      <BoardMetadata report={reportData.report} />
+    </>
+  );
+}

--- a/components/PreviewBoard.tsx
+++ b/components/PreviewBoard.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { notFound } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import type { AccountingReports } from '@/models/type';
+import { Board } from './Board';
+
+export function PreviewBoard() {
+  const [data, setData] = useState<AccountingReports | null>(null);
+  useEffect(() => {
+    const url = new URL(location.href).searchParams.get('url');
+    if (!url) {
+      notFound();
+      return;
+    }
+    fetch(url)
+      .then((response) => response.json())
+      .then((data: AccountingReports) => {
+        setData(data);
+      })
+      .catch(() => {
+        notFound();
+      });
+  }, []);
+
+  return <Board data={data} />;
+}


### PR DESCRIPTION
# 変更の概要
`https://polimoney.dd2030.org/preview?url=`
というページを新規に追加する。

# スクリーンショット
<img width="1020" height="882" alt="image" src="https://github.com/user-attachments/assets/cd08743c-8fb4-4ae5-9e8b-35ebc8ef8066" />

# 変更の背景
新規にデータを追加する際、 public github へ push する前に確認をしたい、という要望があったため。

# 関連Issue
https://github.com/digitaldemocracy2030/polimoney/issues/32

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
