### PR TITLE
feat: SNS共有リンクに名前を追加 & ハッシュタグ追加

### DIFF
--- a/app/[politicianId]/[year]/page.tsx
+++ b/app/[politicianId]/[year]/page.tsx
@@ -82,7 +82,7 @@ export default async function Page({ params }: Props) {
 
   return (
     <Box>
-      <Header />
+      <Header profileName={data.yearData.profile.name} />
       <BoardSummary
         politicianId={politicianId}
         profile={yearData.profile}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import SNSSharePanel from './SNSSharePanel';
 
-export function Header() {
+export function Header({ profileName }: { profileName?: string }) {
   const pathname = usePathname();
 
   return (
@@ -32,7 +32,7 @@ export function Header() {
             <Link href={'#summary'}>収支の流れ</Link>
             <Link href={'#income'}>収入の一覧</Link>
             <Link href={'#expense'}>支出の一覧</Link>
-            <SNSSharePanel className="mr-4" />
+            <SNSSharePanel profileName={profileName ?? ''} className="mr-4" />
           </HStack>
         )}
       </HStack>

--- a/components/SNSSharePanel.tsx
+++ b/components/SNSSharePanel.tsx
@@ -11,13 +11,11 @@ import {
   XIcon,
 } from 'react-share';
 
-const titleMap: Record<string, string> = {
-  '/polimoney': 'Polimoney',
-};
-
 export default function SNSSharePanel({
+  profileName,
   className = '',
 }: {
+  profileName: string;
   className?: string;
 }) {
   const pathname = usePathname();
@@ -30,9 +28,9 @@ export default function SNSSharePanel({
   }, []);
 
   const siteTitle = 'Polimoney';
-  const title = titleMap[pathname];
-  const shareTitle = title ? `${siteTitle} - ${title}` : siteTitle;
+  const shareTitle = profileName ? `${profileName} - ${siteTitle}` : siteTitle;
   const url = `${origin}${pathname}`;
+  const hashTags = ['Polimoney', 'デジタル民主主義2030'];
 
   const SNSButtons = () => (
     <>
@@ -92,10 +90,10 @@ export default function SNSSharePanel({
       <LineShareButton url={url} title={shareTitle}>
         <LineIcon size={32} round />
       </LineShareButton>
-      <FacebookShareButton url={url} title={shareTitle}>
+      <FacebookShareButton url={url} title={shareTitle} hashtag={hashTags[0]}>
         <FacebookIcon size={32} round />
       </FacebookShareButton>
-      <TwitterShareButton url={url} title={shareTitle}>
+      <TwitterShareButton url={url} title={shareTitle} hashtags={hashTags}>
         <XIcon size={32} round />
       </TwitterShareButton>
     </>


### PR DESCRIPTION
# 変更の概要
SNSへの共有リンクに名前とハッシュタグを追加
- タイトルは {政治家さんの名前} + "Polimoney" になるように変更
- react-share では、ハッシュタグもつけられることがわかったため追加
  - Facebook は 1つだけつけられるようになっていたため、 "Polimoney"
  - X は複数つけられるようになっていたため、"Polimoney", "デジタル民主主義2030" 

# スクリーンショット
なし

# 変更の背景
#134 のタイトル変更のみ実施

# 関連Issue
#134 

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * シェア機能で政治家のプロフィール名がSNS共有タイトルに表示されるようになりました。
  * SNS共有時に「Polimoney」と「デジタル民主主義2030」のハッシュタグが自動で追加されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->