### PR TITLE
fix: サムネイルのURLを絶対パスに更新

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
     images: ['/ogp/polimoney.png'],
   },
   other: {
-    thumbnail: '/ogp/polimoney.png',
+    thumbnail: 'https://polimoney.dd2030.org/ogp/polimoney.png',
   },
 };
 


### PR DESCRIPTION
# 変更の概要
thumbnail の指定を相対パスから絶対パスに変更

# スクリーンショット
なし

# 変更の背景
現在、thumbnail が正しく検索結果に表示されない状態のままかと思います。  
今設定している値は相対パスになっていますが、これを絶対パスに変えることでもしかしたら表示されるようになったりしないかなと思っています。

# 関連Issue
#101 

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **その他**
  * サムネイル画像の参照先が相対パスから絶対URLに変更されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->