### PR TITLE
feat: ヘッダーのレスポンシブデザインを改善

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -9,33 +9,70 @@ export function Header({ profileName }: { profileName?: string }) {
 
   return (
     <Box>
-      <HStack
-        justify={{ base: 'center', lg: 'space-between' }}
-        alignItems={'center'}
-        px={10}
-        py={5}
-        background={'linear-gradient(90deg, #FDD2F8 0%, #A6D1FF 100%)'}
-        borderRadius={'full'}
-        color={'#ffffff'}
-        textShadow={'0 0 1px #00000077'}
-      >
-        <Link href={'/'}>
-          <Heading fontSize={'3xl'}>Polimoney</Heading>
-        </Link>
-        {pathname !== '/' && (
-          <HStack
-            fontSize={'sm'}
-            fontWeight={'bold'}
-            gap={8}
-            display={{ base: 'none', lg: 'flex' }}
+      <Box w="full" position="relative">
+        <HStack
+          justify="space-between"
+          position="relative"
+          w="full"
+          px={{ base: 6, md: 10 }}
+          py={5}
+          background={'linear-gradient(90deg, #FDD2F8 0%, #A6D1FF 100%)'}
+          borderRadius={'full'}
+          color={'#ffffff'}
+          textShadow={'0 0 1px #00000077'}
+        >
+          {/* タイトル（デスクトップでは左端、モバイルでは非表示） */}
+          <Box display={{ base: 'none', lg: 'block' }}>
+            <Link href={'/'}>
+              <Heading fontSize={'3xl'}>Polimoney</Heading>
+            </Link>
+          </Box>
+
+          {/* モバイル用：中央のタイトル */}
+          <Box
+            display={{ base: 'block', lg: 'none' }}
+            position="absolute"
+            left="50%"
+            transform="translateX(-50%)"
           >
-            <Link href={'#summary'}>収支の流れ</Link>
-            <Link href={'#income'}>収入の一覧</Link>
-            <Link href={'#expense'}>支出の一覧</Link>
-            <SNSSharePanel profileName={profileName ?? ''} className="mr-4" />
+            <Link href={'/'}>
+              <Heading fontSize={'3xl'}>Polimoney</Heading>
+            </Link>
+          </Box>
+
+          {/* デスクトップ用：右寄せナビゲーション */}
+          <HStack
+            display={{ base: 'none', lg: 'flex' }}
+            gap={8}
+            position="absolute"
+            right={{ base: 6, md: 10 }}
+          >
+            <HStack fontSize={'sm'} fontWeight={'bold'} gap={8}>
+              <Link href={'#summary'}>収支の流れ</Link>
+              <Link href={'#income'}>収入の一覧</Link>
+              <Link href={'#expense'}>支出の一覧</Link>
+            </HStack>
+            {pathname !== '/' && (
+              <Box>
+                <SNSSharePanel profileName={profileName ?? ''} />
+              </Box>
+            )}
           </HStack>
-        )}
-      </HStack>
+
+          {/* モバイル用：共有ボタン（右端に固定配置） */}
+          {pathname !== '/' && (
+            <Box
+              display={{ base: 'block', lg: 'none' }}
+              position="absolute"
+              right={{ base: 6, md: 10 }}
+              top="50%"
+              transform="translateY(-50%)"
+            >
+              <SNSSharePanel profileName={profileName ?? ''} />
+            </Box>
+          )}
+        </HStack>
+      </Box>
       <Text fontSize={'xs'} textAlign={'center'} my={6}>
         政治資金の流れを見える化するプラットフォームです。透明性の高い政治実現を目指して、オープンソースで開発されています。
       </Text>


### PR DESCRIPTION
# 変更の概要
ヘッダーのレスポンシブデザインを改善し、モバイルとデスクトップでの表示を最適化しました。

# スクリーンショット
<img width="557" height="742" alt="スクリーンショット 2025-08-14 19 11 27" src="https://github.com/user-attachments/assets/bebe5bf5-9769-43d0-8fee-6ace49b93374" />

# 変更の背景
- 共有ボタンの表示位置が画面幅によって適切でなかった

# 主な変更点
- モバイル表示時のレイアウトを最適化

# 関連Issue
#172 In digitaldemocracy2030/polimoney;

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - ヘッダーをレスポンシブ対応。デスクトップで右寄せナビ（サマリー・収入・支出）を追加。モバイルは中央タイトルと右端のシェアボタンを表示。シェアは非トップページでのみ表示。
- リファクタ
  - レイアウトを再構成し、絶対/相対配置でデスクトップ・モバイルの配置を最適化。パディングをブレークポイントに応じて調整。
- スタイル
  - ナビの文字サイズ/太さと余白を見直し、視認性を向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->