### PR TITLE
fix: トップページに不要なリンクが表示されてしまっているので修正

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -39,37 +39,35 @@ export function Header({ profileName }: { profileName?: string }) {
               <Heading fontSize={'3xl'}>Polimoney</Heading>
             </Link>
           </Box>
-
-          {/* デスクトップ用：右寄せナビゲーション */}
-          <HStack
-            display={{ base: 'none', lg: 'flex' }}
-            gap={8}
-            position="absolute"
-            right={{ base: 6, md: 10 }}
-          >
-            <HStack fontSize={'sm'} fontWeight={'bold'} gap={8}>
-              <Link href={'#summary'}>収支の流れ</Link>
-              <Link href={'#income'}>収入の一覧</Link>
-              <Link href={'#expense'}>支出の一覧</Link>
-            </HStack>
-            {pathname !== '/' && (
-              <Box>
+          {pathname !== '/' && (
+            <>
+              {/* デスクトップ用：右寄せナビゲーション */}
+              <HStack
+                display={{ base: 'none', lg: 'flex' }}
+                gap={8}
+                position="absolute"
+                right={{ base: 6, md: 10 }}
+              >
+                <HStack fontSize={'sm'} fontWeight={'bold'} gap={8}>
+                  <Link href={'#summary'}>収支の流れ</Link>
+                  <Link href={'#income'}>収入の一覧</Link>
+                  <Link href={'#expense'}>支出の一覧</Link>
+                </HStack>
+                <Box>
+                  <SNSSharePanel profileName={profileName ?? ''} />
+                </Box>
+              </HStack>
+              {/* モバイル用：共有ボタン（右端に固定配置） */}
+              <Box
+                display={{ base: 'block', lg: 'none' }}
+                position="absolute"
+                right={{ base: 6, md: 10 }}
+                top="50%"
+                transform="translateY(-50%)"
+              >
                 <SNSSharePanel profileName={profileName ?? ''} />
               </Box>
-            )}
-          </HStack>
-
-          {/* モバイル用：共有ボタン（右端に固定配置） */}
-          {pathname !== '/' && (
-            <Box
-              display={{ base: 'block', lg: 'none' }}
-              position="absolute"
-              right={{ base: 6, md: 10 }}
-              top="50%"
-              transform="translateY(-50%)"
-            >
-              <SNSSharePanel profileName={profileName ?? ''} />
-            </Box>
+            </>
           )}
         </HStack>
       </Box>


### PR DESCRIPTION
# 変更の概要
トップページに表示されるようになってしまった不要なリンクが表示されなくなるように修正

# スクリーンショット
- 修正前
<img width="1186" height="465" alt="スクリーンショット 2025-08-14 午後10 56 50" src="https://github.com/user-attachments/assets/501601c9-5d32-4809-a305-b9efaa233b13" />

- 修正後
<img width="1164" height="448" alt="スクリーンショット 2025-08-14 午後10 57 16" src="https://github.com/user-attachments/assets/5e119130-da13-4b0e-9eab-4a2b19e72862" />


# 変更の背景
トップページに不要なリンクが表示されてしまっていることに気づいたため修正

# 関連Issue
- 関連するPR
  -   <https://github.com/digitaldemocracy2030/polimoney/pull/176>

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
