### PR TITLE
VS Code のフォーマッタ設定を追加

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,21 @@
 {
-  "cSpell.words": ["bradlc", "devcontainers", "venv"]
+  "cSpell.words": ["bradlc", "devcontainers", "venv"],
+  "[json]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  }
 }


### PR DESCRIPTION
# 変更の概要
Visual Studio Code でのフォーマッタ設定を追加（`.vscode/settings.json`）

# 変更の背景
Visual Studio Code のデフォルト設定として Prettier などの別のフォーマッタを設定している場合でも biome によるフォーマットを行うように設定を追加

# 関連Issue
なし

# CLAへの同意

- [x] CLAの内容を読み、同意しました


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - VS Code 設定を更新し、JSON/JSONC/JavaScript/TypeScript/JSX/TSX の既定フォーマッタを Biome に統一。cSpell の設定を維持しつつ整備。実行時の挙動や機能への影響はありません。
- Style
  - 編集時の自動整形を一貫化し、開発環境間でのコードスタイルの再現性を向上。不要な差分を抑制し、レビュー効率を改善します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->