### PR TITLE
chore: BUG Report の形式不備修正

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: 🐛 DEVバグレポート
 about: システムの不具合や予期しない動作を報告する
 title: ""
-labels: ["DEV", bug"]
+labels: ["DEV", "bug"]
 assignees: ""
 ---
 


### PR DESCRIPTION
# 変更の概要
BUG Report で ダブルクォート が1つ抜けていたので修正

# スクリーンショット
<!-- UIの変更を伴う場合は、変更前後のスクリーンショットもしくはgif画像をこちらに記載してください -->

# 変更の背景
<!-- ここに変更が必要となった背景を記載してください -->

# 関連Issue
<!-- 関連するIssueのリンクをこちらに記載してください -->

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- チョア
  - GitHub のバグ報告テンプレートの YAML 構文エラーを修正し、labels が ["DEV", "bug"] として正しく適用されるようにしました。フロントマターの整合性が保たれ、バグ報告時の自動ラベル付けが安定します。プロダクト機能や画面への影響はありません。
  - 変更は最小で、他の内容変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->