### PR TITLE
feat: backendにemailのバリデーションロジックを追加

### DIFF
--- a/backend/middleware/auth.go
+++ b/backend/middleware/auth.go
@@ -7,12 +7,18 @@ import (
 	"log"
 	"os"
 
+	"github.com/digitaldemocracy2030/polimoney/middleware/validators"
 	"github.com/digitaldemocracy2030/polimoney/models"
 	"golang.org/x/crypto/bcrypt"
 )
 
 // Signup は新規ユーザー登録を行う
 func (um *UserMiddleware) Signup(username, email, password string) (*models.User, error) {
+	// Emailのバリデーション
+	if err := validators.ValidateEmail(email); err != nil {
+		return nil, fmt.Errorf("無効なメールアドレスです")
+	}
+
 	// パスワードをsha256ハッシュ化
 	// bcryptの72バイト制限回避のため
 	salt := os.Getenv("PASSWORD_SALT")

--- a/backend/middleware/validators/user_validator.go
+++ b/backend/middleware/validators/user_validator.go
@@ -1,0 +1,20 @@
+package validators
+
+import (
+	"errors"
+	"fmt"
+	"net/mail"
+)
+
+// ValidateEmail checks if the email format is valid.
+func ValidateEmail(email string) error {
+	// 空の場合はエラー
+	if email == "" {
+		return errors.New("email is required")
+	}
+	_, err := mail.ParseAddress(email)
+	if err != nil {
+		return fmt.Errorf("invalid email format: %w", err)
+	}
+	return nil
+}

--- a/backend/middleware/validators/user_validator_test.go
+++ b/backend/middleware/validators/user_validator_test.go
@@ -1,0 +1,65 @@
+package validators
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateEmail(t *testing.T) {
+	// --- 正常系テストケース ---
+	validTestCases := []struct {
+		name  string
+		email string
+	}{
+		{
+			name:  "valid email",
+			email: "test@example.com",
+		},
+		{
+			name:  "valid email with subdomain",
+			email: "test@sub.example.com",
+		},
+	}
+
+	for _, tc := range validTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateEmail(tc.email)
+			assert.NoError(t, err)
+		})
+	}
+
+	// --- 異常系テストケース ---
+	invalidTestCases := []struct {
+		name  string
+		email string
+	}{
+		{
+			name:  "invalid email - no at sign",
+			email: "testexample.com",
+		},
+		{
+			name:  "invalid email - no domain",
+			email: "test@",
+		},
+		{
+			name:  "invalid email - no local part",
+			email: "@example.com",
+		},
+		{
+			name:  "invalid email - multiple at signs",
+			email: "test@@example.com",
+		},
+		{
+			name:  "empty email",
+			email: "",
+		},
+	}
+
+	for _, tc := range invalidTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateEmail(tc.email)
+			assert.Error(t, err)
+		})
+	}
+}


### PR DESCRIPTION
# 変更の概要

バックエンドのユーザー登録処理において、メールアドレスの形式を検証するバリデーション機能を追加しました。

主な変更点は以下の通りです。
- `middleware.Signup` 関数にバリデーションチェックを導入
- バリデーションロジックを責務分離のため `middleware/validators` パッケージとして新規作成
- `net/mail` 標準パッケージを利用した堅牢なメールアドレス形式チェック
- テスト駆動開発（TDD）に基づき、バリデーション用のテストコードを実装

# スクリーンショット
<!-- UIの変更を伴う場合は、変更前後のスクリーンショットもしくはgif画像をこちらに記載してください -->

# 変更の背景

これまでユーザー登録時にメールアドレスの形式チェックが行われておらず、不正な形式のデータが登録される可能性がありました。
この変更により、サーバーサイドでメールアドレスの有効性を検証し、データの整合性を担保することを目的としています。
また、今後の拡張性を考慮し、バリデーションに関するロジックは独立したパッケージとして実装しました。

# 関連Issue

https://github.com/digitaldemocracy2030/polimoney/issues/180

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - サインアップ時にメールアドレスの形式を検証し、不正な場合は「無効なメールアドレスです」と表示されるようになりました。入力品質の向上により、登録時のエラーを早期に発見できます。
- テスト
  - 代表的な有効・無効なメールアドレスを対象にした検証テストを追加し、バリデーションの動作を確認しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->