### PR TITLE
chore: 関連するjs/tsのコードが変更された場合のみnextjs-checkが実行されるようにpathを追加

### DIFF
--- a/.github/workflows/nextjs-check.yml
+++ b/.github/workflows/nextjs-check.yml
@@ -3,6 +3,16 @@ name: Check Next.js
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - 'app/**'
+      - 'components/**'
+      - 'data/**'
+      - 'models/**'
+      - 'public/**'
+      - 'next.config.ts'
+      - 'tsconfig.json'
+      - 'package.json'
+      - 'package-lock.json'
 
 jobs:
   lint:
@@ -58,7 +68,6 @@ jobs:
           else
             yarn run lint
           fi
-      
       - name: Build
         run: |
           if [ "${{ steps.detect-package-manager.outputs.manager }}" = "npm" ]; then


### PR DESCRIPTION
# 変更の概要
関連するjsのコードが変更された場合のみ当ワークフローを実行されるようにして、github actionsを節約できるようにしました。


# スクリーンショット
<!-- UIの変更を伴う場合は、変更前後のスクリーンショットもしくはgif画像をこちらに記載してください -->

# 変更の背景

現在、リポジトリ上でどのような変更がプッシュされたときでも、nextjs-check.ymlが実行されるため。

# 関連Issue

https://github.com/digitaldemocracy2030/polimoney/issues/187

<!-- 関連するIssueのリンクをこちらに記載してください -->

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
