### PR TITLE
支出の部 1 人件費までできた

### DIFF
--- a/tools_election/main.py
+++ b/tools_election/main.py
@@ -4,6 +4,7 @@ import sys
 import openpyxl
 
 from wakayama.income import get_income
+from wakayama.personnel import get_personnel
 
 # ログ設定
 logging.basicConfig(
@@ -16,7 +17,7 @@ def analyze(input_file):
 
     # 各シートを取得
     income = wb["収入"]
-    # personnel = wb["人件"]
+    personnel = wb["人件"]
     # building = wb["家屋"]
     # communication = wb["通信"]
     # transportation = wb["交通"]
@@ -30,6 +31,7 @@ def analyze(input_file):
 
     # 分析
     get_income(income)
+    get_personnel(personnel)
 
 
 def main():

--- a/tools_election/wakayama/income.py
+++ b/tools_election/wakayama/income.py
@@ -65,7 +65,7 @@ def get_total_income(income: Worksheet):
     min_row = 7
 
     for row in income.iter_rows(min_row=min_row, max_col=C_COL + 1):
-        # A列が "計" でない場合はスキップ
+        # B列が寄附, その他の収入, 計, 総計のいずれでもなければスキップ
         if row[B_COL].value not in ["寄附", "その他の収入", "計", "総計"]:
             continue
         # 9行取得したら終了

--- a/tools_election/wakayama/personnel.py
+++ b/tools_election/wakayama/personnel.py
@@ -1,0 +1,89 @@
+import json
+
+from openpyxl import utils
+from openpyxl.worksheet.worksheet import Worksheet
+
+# AからJの列インデックスを取得（0始まり）
+A_COL = utils.column_index_from_string("A") - 1
+B_COL = utils.column_index_from_string("B") - 1
+C_COL = utils.column_index_from_string("C") - 1
+E_COL = utils.column_index_from_string("E") - 1
+F_COL = utils.column_index_from_string("F") - 1
+K_COL = utils.column_index_from_string("K") - 1
+
+
+def get_individual_personnel(personnel: Worksheet):
+    """人件の部の個別データを取得する
+
+    Args:
+        personnel (Worksheet): 人件の部のシート
+    """
+
+    personnel_data = []
+
+    # 4行目以降, AからJの列を取得
+    min_row = 4
+    for row in personnel.iter_rows(min_row=min_row, max_col=K_COL + 1):
+        date_cell = row[A_COL]
+        price_cell = row[C_COL]
+        category_cell = row[E_COL]
+        purpose_cell = row[F_COL]
+        note_cell = row[K_COL]
+        # Noneになったら終了
+        if date_cell.value is None:
+            break
+
+        personnel_data.append(
+            {
+                "date": date_cell.value.strftime("%Y-%m-%d"),
+                "price": int(price_cell.value),
+                "category": category_cell.value,
+                "purpose": purpose_cell.value,
+                "note": note_cell.value,
+            }
+        )
+
+    return personnel_data
+
+
+def get_total_personnel(personnel: Worksheet):
+    """人件の部の合計データを取得する
+    合計に関する記述は3行あり、位置は個別データの数によって変わるので、動的に取得する
+
+    Args:
+        personnel (Worksheet): 人件の部のシート
+    """
+
+    total_personnel_data = []
+    count = 0
+
+    # 合計に関する記述は16行目より下にある
+    min_row = 16
+
+    for row in personnel.iter_rows(min_row=min_row, max_col=C_COL + 1):
+        # 型をチェック
+        value = row[B_COL].value
+        if not isinstance(value, str):
+            continue
+
+        # B列が立候補準備のための支出、選挙運動のための支出、計のいずれでもなければスキップ
+        value_str = value.strip().replace("　", "")
+        if value_str not in ["立候補準備のための支出", "選挙運動のための支出", "計"]:
+            continue
+
+        # 3行取得したら終了
+        if count == 3:
+            break
+
+        total_personnel_data.append({"name": value_str, "price": row[C_COL].value})
+        count += 1
+
+    return total_personnel_data
+
+
+def get_personnel(personnel: Worksheet):
+    individual_personnel = get_individual_personnel(personnel)
+    print(json.dumps(individual_personnel, indent=4, ensure_ascii=False))
+
+    total_personnel = get_total_personnel(personnel)
+    print(json.dumps(total_personnel, indent=4, ensure_ascii=False))


### PR DESCRIPTION
# 変更の概要
<!-- ここに変更の概要を記載してください -->
#190 つづき
人件費の分析までできた

# スクリーンショット
<!-- UIの変更を伴う場合は、変更前後のスクリーンショットもしくはgif画像をこちらに記載してください -->

# 変更の背景
<!-- ここに変更が必要となった背景を記載してください -->

# 関連Issue
<!-- 関連するIssueのリンクをこちらに記載してください -->
#191 

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [ ] CLAの内容を読み、同意しました


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - 人件費データの解析・出力に対応。収支分析フローに人件費シートを追加し、個別明細と合計をJSONで表示します。既存の収入解析は従来通り動作します。
- ドキュメント
  - 収入集計の列参照に関するコメントを更新（列Bを明記）。機能変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->