### PR TITLE
支出(計)も対応

### DIFF
--- a/tools_election/main.py
+++ b/tools_election/main.py
@@ -7,6 +7,7 @@ import openpyxl
 from wakayama.building import get_building
 from wakayama.general import get_general
 from wakayama.income import get_income
+from wakayama.total import get_total
 
 # ログ設定
 logging.basicConfig(
@@ -31,52 +32,52 @@ def analyze(input_file):
     building = wb["家屋"]
     communication = wb["通信"]
     transportation = wb["交通"]
-    # printing = wb["印刷"]
+    printing = wb["印刷"]
     advertising = wb["広告"]
     stationery = wb["文具"]
     food = wb["食料"]
     accommodation = wb["休泊"]
     miscellaneous = wb["雑費"]
-    # total = wb["合計"]
+    total = wb["支出 (計)"]
 
     # 分析
     income_data = get_income(income)  # 収入
-    personnel_data = get_general(personnel)  # 人件
+    personnel_data = get_general(personnel, "personnel")  # 人件
     building_data = get_building(building)  # 家屋
-    communication_data = get_general(communication)  # 通信
-    transportation_data = get_general(transportation)  # 交通
-    # printing_data = get_printing(printing)  # 印刷
-    advertising_data = get_general(advertising)  # 広告
-    stationery_data = get_general(stationery)  # 文具
-    food_data = get_general(food)  # 食料
-    accommodation_data = get_general(accommodation)  # 休泊
-    miscellaneous_data = get_general(miscellaneous)  # 雑費
-    # total_data = get_total(total)  # 合計
+    communication_data = get_general(communication, "communication")  # 通信
+    transportation_data = get_general(transportation, "transportation")  # 交通
+    printing_data = get_general(printing, "printing")  # 印刷
+    advertising_data = get_general(advertising, "advertising")  # 広告
+    stationery_data = get_general(stationery, "stationery")  # 文具
+    food_data = get_general(food, "food")  # 食料
+    accommodation_data = get_general(accommodation, "accommodation")  # 休泊
+    miscellaneous_data = get_general(miscellaneous, "miscellaneous")  # 雑費
+    total_data = get_total(total)  # 合計
 
-    with open("income_data.json", "w", encoding="utf-8") as f:
+    with open("output_json/income_data.json", "w", encoding="utf-8") as f:
         json.dump(income_data, f, indent=4, ensure_ascii=False)
-    with open("personnel_data.json", "w", encoding="utf-8") as f:
+    with open("output_json/personnel_data.json", "w", encoding="utf-8") as f:
         json.dump(personnel_data, f, indent=4, ensure_ascii=False)
-    with open("building_data.json", "w", encoding="utf-8") as f:
+    with open("output_json/building_data.json", "w", encoding="utf-8") as f:
         json.dump(building_data, f, indent=4, ensure_ascii=False)
-    with open("communication_data.json", "w", encoding="utf-8") as f:
+    with open("output_json/communication_data.json", "w", encoding="utf-8") as f:
         json.dump(communication_data, f, indent=4, ensure_ascii=False)
-    with open("transportation_data.json", "w", encoding="utf-8") as f:
+    with open("output_json/transportation_data.json", "w", encoding="utf-8") as f:
         json.dump(transportation_data, f, indent=4, ensure_ascii=False)
-    # with open("printing_data.json", "w", encoding="utf-8") as f:
-    #     json.dump(printing_data, f, indent=4, ensure_ascii=False)
-    with open("advertising_data.json", "w", encoding="utf-8") as f:
+    with open("output_json/printing_data.json", "w", encoding="utf-8") as f:
+        json.dump(printing_data, f, indent=4, ensure_ascii=False)
+    with open("output_json/advertising_data.json", "w", encoding="utf-8") as f:
         json.dump(advertising_data, f, indent=4, ensure_ascii=False)
-    with open("stationery_data.json", "w", encoding="utf-8") as f:
+    with open("output_json/stationery_data.json", "w", encoding="utf-8") as f:
         json.dump(stationery_data, f, indent=4, ensure_ascii=False)
-    with open("food_data.json", "w", encoding="utf-8") as f:
+    with open("output_json/food_data.json", "w", encoding="utf-8") as f:
         json.dump(food_data, f, indent=4, ensure_ascii=False)
-    with open("accommodation_data.json", "w", encoding="utf-8") as f:
+    with open("output_json/accommodation_data.json", "w", encoding="utf-8") as f:
         json.dump(accommodation_data, f, indent=4, ensure_ascii=False)
-    with open("miscellaneous_data.json", "w", encoding="utf-8") as f:
+    with open("output_json/miscellaneous_data.json", "w", encoding="utf-8") as f:
         json.dump(miscellaneous_data, f, indent=4, ensure_ascii=False)
-    # with open("total_data.json", "w", encoding="utf-8") as f:
-    #     json.dump(total_data, f, indent=4, ensure_ascii=False)
+    with open("output_json/total_data.json", "w", encoding="utf-8") as f:
+        json.dump(total_data, f, indent=4, ensure_ascii=False)
 
 
 def main():

--- a/tools_election/wakayama/building.py
+++ b/tools_election/wakayama/building.py
@@ -74,7 +74,11 @@ def get_total_election_office(building: Worksheet):
         if count == 3:
             break
 
-        total_building_data.append({"name": value_str, "price": row[C_COL].value})
+        price_value = row[C_COL].value
+        # Excelの計算による小数点誤差を避けるため、整数に変換
+        if price_value is not None:
+            price_value = int(price_value)
+        total_building_data.append({"name": value_str, "price": price_value})
         count += 1
 
     return total_building_data
@@ -163,7 +167,11 @@ def get_total_meeting_venue(building: Worksheet):
         if count == 3:
             break
 
-        total_meeting_venue_data.append({"name": value_str, "price": row[C_COL].value})
+        price_value = row[C_COL].value
+        # Excelの計算による小数点誤差を避けるため、整数に変換
+        if price_value is not None:
+            price_value = int(price_value)
+        total_meeting_venue_data.append({"name": value_str, "price": price_value})
         count += 1
 
     return total_meeting_venue_data

--- a/tools_election/wakayama/general.py
+++ b/tools_election/wakayama/general.py
@@ -28,12 +28,14 @@ def get_individual_general(general: Worksheet):
         purpose_cell = row[F_COL]
         note_cell = row[K_COL]
         # Noneになったら終了
-        if date_cell.value is None:
+        if price_cell.value is None:
             break
 
         general_data.append(
             {
-                "date": date_cell.value.strftime("%Y-%m-%d"),
+                "date": date_cell.value.strftime("%Y-%m-%d")
+                if date_cell.value
+                else None,  # 日付は無い場合もある
                 "price": int(price_cell.value),
                 "category": category_cell.value,
                 "purpose": purpose_cell.value,
@@ -73,18 +75,22 @@ def get_total_general(general: Worksheet):
         if count == 3:
             break
 
-        total_general_data.append({"name": value_str, "price": row[C_COL].value})
+        price_value = row[C_COL].value
+        # Excelの計算による小数点誤差を避けるため、整数に変換
+        if price_value is not None:
+            price_value = int(price_value)
+        total_general_data.append({"name": value_str, "price": price_value})
         count += 1
 
     return total_general_data
 
 
-def get_general(general: Worksheet):
+def get_general(general: Worksheet, name: str):
     individual_general = get_individual_general(general)
 
     total_general = get_total_general(general)
 
     return {
-        "individual_general": individual_general,
-        "total_general": total_general,
+        f"individual_{name}": individual_general,
+        f"total_{name}": total_general,
     }

--- a/tools_election/wakayama/income.py
+++ b/tools_election/wakayama/income.py
@@ -74,6 +74,9 @@ def get_total_income(income: Worksheet):
         name_value = row[B_COL].value
         price_value = row[C_COL].value
 
+        # Excelの計算による小数点誤差を避けるため、整数に変換
+        if price_value is not None:
+            price_value = int(price_value)
         total_income_data.append({"name": name_value, "price": price_value})
         count += 1
 

--- a/tools_election/wakayama/total.py
+++ b/tools_election/wakayama/total.py
@@ -19,7 +19,7 @@ def extract_number(value):
         value: 抽出対象の値（数値、文字列など）
 
     Returns:
-        int or None: 抽出された数値（小数点がある場合は整数に変換）、抽出できない場合はNone
+        int or float or None: 抽出された数値（小数点がある場合は整数に変換）、抽出できない場合はNone
     """
     if value is None:
         return None

--- a/tools_election/wakayama/total.py
+++ b/tools_election/wakayama/total.py
@@ -1,0 +1,108 @@
+import re
+
+from openpyxl import utils
+from openpyxl.worksheet.worksheet import Worksheet
+
+# AからJの列インデックスを取得（0始まり）
+B_COL = utils.column_index_from_string("B") - 1
+C_COL = utils.column_index_from_string("C") - 1
+G_COL = utils.column_index_from_string("G") - 1
+H_COL = utils.column_index_from_string("H") - 1
+I_COL = utils.column_index_from_string("I") - 1
+
+
+def extract_number(value):
+    """
+    値から数字のみを抽出する（小数点対応）
+
+    Args:
+        value: 抽出対象の値（数値、文字列など）
+
+    Returns:
+        int or None: 抽出された数値（小数点がある場合は整数に変換）、抽出できない場合はNone
+    """
+    if value is None:
+        return None
+
+    # 既に数値の場合はそのまま整数に変換
+    if isinstance(value, (int, float)):
+        return int(value)
+
+    # 文字列から数字（小数点含む）を抽出
+    if isinstance(value, str):
+        # カンマを除去してから数字と小数点のみを抽出するパターン
+        clean_value = value.replace(",", "")
+        match = re.search(r"(\d+(?:\.\d+)?)", clean_value)
+        if match:
+            num_str = match.group(1)
+            if "." in num_str:
+                return float(num_str)
+            else:
+                return int(num_str)
+
+    return None
+
+
+def get_individual_total(total: Worksheet):
+    """合計の個別データを取得する
+    合計に関しては、データの追加はないため、4~13列目を指定するだけで取得できる
+
+    Args:
+        total (Worksheet): 合計のシート
+    """
+
+    total_data = []
+
+    # 4~13列目を取得
+    for i, row in enumerate(total.iter_rows(min_row=5, max_row=13, max_col=C_COL + 1)):
+        if 0 <= i <= 2:
+            name = "計 " + row[B_COL].value
+        elif 3 <= i <= 5:
+            name = "前回計 " + row[B_COL].value
+        elif 6 <= i <= 8:
+            name = "総計 " + row[B_COL].value
+        price_value = row[C_COL].value
+        # Excelの計算による小数点誤差を避けるため、整数に変換
+        if price_value is not None:
+            price_value = int(price_value)
+        total_data.append({"name": name, "price": price_value})
+
+    return total_data
+
+
+def get_public_expense_equivalent_total(total: Worksheet):
+    """支出のうち公費負担相当額のデータを取得する
+
+    Args:
+        total (Worksheet): 合計のシート
+    """
+
+    get_public_expense_equivalent_total_data = []
+
+    for row in total.iter_rows(min_row=15, max_row=23, max_col=I_COL + 1):
+        get_public_expense_equivalent_total_data.append(
+            {
+                "item": row[C_COL].value,  # 項目（C列）
+                "unit_price": extract_number(row[G_COL].value),  # 単価（G列）
+                "quantity": extract_number(row[H_COL].value),  # 枚数（H列）
+                "price": extract_number(row[I_COL].value),  # 金額（I列）
+            }
+        )
+
+    return get_public_expense_equivalent_total_data
+
+
+def get_total(total: Worksheet):
+    """合計のデータを取得する
+
+    Args:
+        total (Worksheet): 合計のシート
+    """
+
+    individual_total = get_individual_total(total)
+    public_expense_equivalent_total = get_public_expense_equivalent_total(total)
+
+    return {
+        "individual_total": individual_total,
+        "public_expense_equivalent_total": public_expense_equivalent_total,
+    }


### PR DESCRIPTION
# 変更の概要
<!-- ここに変更の概要を記載してください -->
#191 つづき
これで完成

# スクリーンショット
<!-- UIの変更を伴う場合は、変更前後のスクリーンショットもしくはgif画像をこちらに記載してください -->

# 変更の背景
<!-- ここに変更が必要となった背景を記載してください -->

# 関連Issue
<!-- 関連するIssueのリンクをこちらに記載してください -->

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - 合計シートの集計に対応し、total_data.json を出力
  - 印刷費のデータ出力を有効化

- 不具合修正
  - 価格を整数化し、小数・浮動小数点の誤差や None を適切に処理
  - 日別データ取得時、価格未入力行での終了条件を見直し

- リファクタ
  - すべてのJSON出力を output_json/ ディレクトリに集約
  - 各カテゴリJSONのキー名を individual_{category} / total_{category} に統一
  - 出力ファイル構成の見直し（income, personnel, building, communication, transportation, printing, advertising, stationery, food, accommodation, miscellaneous, total）

<!-- end of auto-generated comment: release notes by coderabbit.ai -->