### PR TITLE
Docker イメージのバージョン設定を変更

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/javascript-node:20
+FROM mcr.microsoft.com/devcontainers/javascript-node:20-bookworm
 
 # Install Python and required system dependencies
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
## 変更の概要

Docker イメージのベース OS を固定


## 変更の背景

`mcr.microsoft.com/devcontainers/javascript-node:20` はベース OS が複数あるため、
環境によっては apt リポジトリ変更による Python 環境構築エラーなどが発生する場合がある

本日開発コンテナを再構築したところ、
ベース OS が以前と変わっており、apt リポジトリも変更になった影響で Python のインストールに失敗した
OS を固定することで解消した


## CLAへの同意

本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- チョア
  - 開発用コンテナのベースOSを Bookworm 版に更新。パッケージ入手性とセキュリティ更新の追従性を改善。
  - 既存のセットアップ手順（Python/Poetry/npm/venv）は従来どおりの構成で継続し、再構築時の依存解決がより安定。
  - 将来的な開発ツールとの互換性向上を見込み。アプリの機能や挙動への影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->