### PR TITLE
グラフ周りのレイアウトを修正

### DIFF
--- a/components/election-finance/TransactionSection.tsx
+++ b/components/election-finance/TransactionSection.tsx
@@ -200,7 +200,7 @@ export function TransactionSection({
       <Heading as="h2" size="lg" mb={6}>
         {title}
       </Heading>
-      <SimpleGrid columns={{ base: 1, md: 2 }} gap={6}>
+      <SimpleGrid columns={{ base: 1, md: 2 }} gap={2}>
         <Box w="100%" aspectRatio={1} overflow="visible">
           <ResponsivePie
             data={chartItems}
@@ -245,23 +245,19 @@ export function TransactionSection({
             )}
           />
         </Box>
-        <Box>
-          <Stack gap={2}>
-            {chartItems.map((item) => (
-              <HStack key={item.id} justify="space-between">
-                <HStack>
-                  <Box w={3} h={3} borderRadius="full" bg={colorMap[item.id]} />
-                  <Text>
-                    {title === '支出' ? `${item.label}費` : item.label}
-                  </Text>
-                </HStack>
-                <Badge variant="outline" colorPalette={badgeColorPalette}>
-                  {formatCurrency(item.value)}
-                </Badge>
+        <Stack gap={2}>
+          {chartItems.map((item) => (
+            <HStack key={item.id} justify="space-between">
+              <HStack>
+                <Box w={3} h={3} borderRadius="full" bg={colorMap[item.id]} />
+                <Text>{item.label}</Text>
               </HStack>
-            ))}
-          </Stack>
-        </Box>
+              <Badge variant="outline" colorPalette={badgeColorPalette}>
+                {formatCurrency(item.value)}
+              </Badge>
+            </HStack>
+          ))}
+        </Stack>
       </SimpleGrid>
       <Accordion.Root collapsible defaultValue={[]} mt={6}>
         <Accordion.Item value="details">


### PR DESCRIPTION
## 変更の概要

グラフ周りのレイアウトを修正


# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **UI改良**
  * 取引セクションの詳細表示レイアウトをシンプル化し、より コンパクトに改善しました。
  * 凡例と詳細リストの表示を統一し、スペース効率を向上させました。
  * 詳細情報の読みやすさと視認性を最適化しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->